### PR TITLE
Always toast project delete

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -336,14 +336,12 @@ angular.module("openshiftCommonUI")
 ;'use strict';
 
 angular.module("openshiftCommonUI")
-  .directive("deleteProject", function ($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, AlertMessageService, NotificationsService, Logger) {
+  .directive("deleteProject", function ($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, NotificationsService, Logger) {
     return {
       restrict: "E",
       scope: {
         // The name of project to delete
         projectName: "@",
-        // Alerts object for using inline notifications for success and error alerts, notifications are also sent to enable toast notification display.
-        alerts: "=",
         // Optional display name of the project to delete.
         displayName: "@",
         // Set to true to disable the delete button.
@@ -372,11 +370,6 @@ angular.module("openshiftCommonUI")
       replace: true,
       link: function(scope, element, attrs) {
         var showAlert = function(alert) {
-          if (scope.stayOnCurrentPage) {
-            scope.alerts[alert.name] = alert.data;
-          } else {
-            AlertMessageService.addAlert(alert);
-          }
           NotificationsService.addNotification(alert.data);
         };
 
@@ -443,7 +436,6 @@ angular.module("openshiftCommonUI")
                 message: _.capitalize(formattedResource) + "\'" + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
               };
-              scope.alerts[projectName] = alert;
               NotificationsService.addNotification(alert);
               Logger.error(formattedResource + " could not be deleted.", err);
             });

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -507,14 +507,12 @@ angular.module("openshiftCommonUI")
 ;'use strict';
 
 angular.module("openshiftCommonUI")
-  .directive("deleteProject", ["$uibModal", "$location", "$filter", "$q", "hashSizeFilter", "APIService", "DataService", "AlertMessageService", "NotificationsService", "Logger", function ($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, AlertMessageService, NotificationsService, Logger) {
+  .directive("deleteProject", ["$uibModal", "$location", "$filter", "$q", "hashSizeFilter", "APIService", "DataService", "NotificationsService", "Logger", function ($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, NotificationsService, Logger) {
     return {
       restrict: "E",
       scope: {
         // The name of project to delete
         projectName: "@",
-        // Alerts object for using inline notifications for success and error alerts, notifications are also sent to enable toast notification display.
-        alerts: "=",
         // Optional display name of the project to delete.
         displayName: "@",
         // Set to true to disable the delete button.
@@ -543,11 +541,6 @@ angular.module("openshiftCommonUI")
       replace: true,
       link: function(scope, element, attrs) {
         var showAlert = function(alert) {
-          if (scope.stayOnCurrentPage) {
-            scope.alerts[alert.name] = alert.data;
-          } else {
-            AlertMessageService.addAlert(alert);
-          }
           NotificationsService.addNotification(alert.data);
         };
 
@@ -614,7 +607,6 @@ angular.module("openshiftCommonUI")
                 message: _.capitalize(formattedResource) + "\'" + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
               };
-              scope.alerts[projectName] = alert;
               NotificationsService.addNotification(alert);
               Logger.error(formattedResource + " could not be deleted.", err);
             });

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -129,12 +129,11 @@ cb && cb();
 };
 } ]
 };
-} ]), angular.module("openshiftCommonUI").directive("deleteProject", [ "$uibModal", "$location", "$filter", "$q", "hashSizeFilter", "APIService", "DataService", "AlertMessageService", "NotificationsService", "Logger", function($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, AlertMessageService, NotificationsService, Logger) {
+} ]), angular.module("openshiftCommonUI").directive("deleteProject", [ "$uibModal", "$location", "$filter", "$q", "hashSizeFilter", "APIService", "DataService", "NotificationsService", "Logger", function($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, NotificationsService, Logger) {
 return {
 restrict:"E",
 scope:{
 projectName:"@",
-alerts:"=",
 displayName:"@",
 disableDelete:"=?",
 typeNameToConfirm:"=?",
@@ -150,7 +149,7 @@ return angular.isDefined(attr.buttonOnly) ? "src/components/delete-project/delet
 replace:!0,
 link:function(scope, element, attrs) {
 var showAlert = function(alert) {
-scope.stayOnCurrentPage ? scope.alerts[alert.name] = alert.data :AlertMessageService.addAlert(alert), NotificationsService.addNotification(alert.data);
+NotificationsService.addNotification(alert.data);
 }, navigateToList = function() {
 if (!scope.stayOnCurrentPage) {
 if (scope.redirectUrl) return void $location.url(scope.redirectUrl);
@@ -185,7 +184,7 @@ type:"error",
 message:_.capitalize(formattedResource) + "' could not be deleted.",
 details:$filter("getErrorDetails")(err)
 };
-scope.alerts[projectName] = alert, NotificationsService.addNotification(alert), Logger.error(formattedResource + " could not be deleted.", err);
+NotificationsService.addNotification(alert), Logger.error(formattedResource + " could not be deleted.", err);
 });
 });
 }

--- a/src/components/delete-project/deleteProject.js
+++ b/src/components/delete-project/deleteProject.js
@@ -1,14 +1,12 @@
 'use strict';
 
 angular.module("openshiftCommonUI")
-  .directive("deleteProject", function ($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, AlertMessageService, NotificationsService, Logger) {
+  .directive("deleteProject", function ($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, NotificationsService, Logger) {
     return {
       restrict: "E",
       scope: {
         // The name of project to delete
         projectName: "@",
-        // Alerts object for using inline notifications for success and error alerts, notifications are also sent to enable toast notification display.
-        alerts: "=",
         // Optional display name of the project to delete.
         displayName: "@",
         // Set to true to disable the delete button.
@@ -37,11 +35,6 @@ angular.module("openshiftCommonUI")
       replace: true,
       link: function(scope, element, attrs) {
         var showAlert = function(alert) {
-          if (scope.stayOnCurrentPage) {
-            scope.alerts[alert.name] = alert.data;
-          } else {
-            AlertMessageService.addAlert(alert);
-          }
           NotificationsService.addNotification(alert.data);
         };
 
@@ -108,7 +101,6 @@ angular.module("openshiftCommonUI")
                 message: _.capitalize(formattedResource) + "\'" + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
               };
-              scope.alerts[projectName] = alert;
               NotificationsService.addNotification(alert);
               Logger.error(formattedResource + " could not be deleted.", err);
             });


### PR DESCRIPTION
Use toast notifications always instead of inline alerts when users delete projects.

Fixes #59

@jeff-phillips-18 @jwforres @serenamarie125 any objections to this change?