### PR TITLE
Remove extra `'` character from delete notification

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -419,7 +419,7 @@ angular.module("openshiftCommonUI")
                 name: projectName,
                 data: {
                   type: "success",
-                  message: _.capitalize(formattedResource) + " was marked for deletion."
+                  message: formattedResource + " was marked for deletion."
                 }
               });
 
@@ -433,7 +433,7 @@ angular.module("openshiftCommonUI")
               // called if failure to delete
               var alert = {
                 type: "error",
-                message: _.capitalize(formattedResource) + "\'" + " could not be deleted.",
+                message: formattedResource + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
               };
               NotificationsService.addNotification(alert);

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -590,7 +590,7 @@ angular.module("openshiftCommonUI")
                 name: projectName,
                 data: {
                   type: "success",
-                  message: _.capitalize(formattedResource) + " was marked for deletion."
+                  message: formattedResource + " was marked for deletion."
                 }
               });
 
@@ -604,7 +604,7 @@ angular.module("openshiftCommonUI")
               // called if failure to delete
               var alert = {
                 type: "error",
-                message: _.capitalize(formattedResource) + "\'" + " could not be deleted.",
+                message: formattedResource + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
               };
               NotificationsService.addNotification(alert);

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -175,13 +175,13 @@ showAlert({
 name:projectName,
 data:{
 type:"success",
-message:_.capitalize(formattedResource) + " was marked for deletion."
+message:formattedResource + " was marked for deletion."
 }
 }), scope.success && scope.success(), navigateToList();
 })["catch"](function(err) {
 var alert = {
 type:"error",
-message:_.capitalize(formattedResource) + "' could not be deleted.",
+message:formattedResource + " could not be deleted.",
 details:$filter("getErrorDetails")(err)
 };
 NotificationsService.addNotification(alert), Logger.error(formattedResource + " could not be deleted.", err);

--- a/src/components/delete-project/deleteProject.js
+++ b/src/components/delete-project/deleteProject.js
@@ -84,7 +84,7 @@ angular.module("openshiftCommonUI")
                 name: projectName,
                 data: {
                   type: "success",
-                  message: _.capitalize(formattedResource) + " was marked for deletion."
+                  message: formattedResource + " was marked for deletion."
                 }
               });
 
@@ -98,7 +98,7 @@ angular.module("openshiftCommonUI")
               // called if failure to delete
               var alert = {
                 type: "error",
-                message: _.capitalize(formattedResource) + "\'" + " could not be deleted.",
+                message: formattedResource + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
               };
               NotificationsService.addNotification(alert);


### PR DESCRIPTION
There is an unintentional double `'` in the message.

![openshift web console 2017-05-10 15-42-22](https://cloud.githubusercontent.com/assets/1167259/25917918/a8d6ab74-3597-11e7-9676-373960087a40.png)

Also removed the call to `_.capitalize` since `formattedResource` is already capitalized.