### PR TITLE
Move ResourceGroupVersion constructor to service to eliminate global

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -203,45 +203,48 @@ angular.module("openshiftCommonServices")
   });
 ;'use strict';
 
-// ResourceGroupVersion represents a fully qualified resource
-function ResourceGroupVersion(resource, group, version) {
-  this.resource = resource;
-  this.group    = group;
-  this.version  = version;
-  return this;
-}
-// toString() includes the group and version information if present
-ResourceGroupVersion.prototype.toString = function() {
-  var s = this.resource;
-  if (this.group)   { s += "/" + this.group;   }
-  if (this.version) { s += "/" + this.version; }
-  return s;
-};
-// primaryResource() returns the resource with any subresources removed
-ResourceGroupVersion.prototype.primaryResource = function() {
-  if (!this.resource) { return ""; }
-  var i = this.resource.indexOf('/');
-  if (i === -1) { return this.resource; }
-  return this.resource.substring(0,i);
-};
-// subresources() returns a (possibly empty) list of subresource segments
-ResourceGroupVersion.prototype.subresources = function() {
-  var segments = (this.resource || '').split("/");
-  segments.shift();
-  return segments;
-};
-// equals() returns true if the given resource, group, and version match.
-// If omitted, group and version are not compared.
-ResourceGroupVersion.prototype.equals = function(resource, group, version) {
-  if (this.resource !== resource) { return false; }
-  if (arguments.length === 1)     { return true;  }
-  if (this.group !== group)       { return false; }
-  if (arguments.length === 2)     { return true;  }
-  if (this.version !== version)   { return false; }
-  return true;
-};
-
 angular.module('openshiftCommonServices')
+.factory('ResourceGroupVersion', function() {
+  // ResourceGroupVersion represents a fully qualified resource
+  function ResourceGroupVersion(resource, group, version) {
+    this.resource = resource;
+    this.group    = group;
+    this.version  = version;
+    return this;
+  }
+  // toString() includes the group and version information if present
+  ResourceGroupVersion.prototype.toString = function() {
+    var s = this.resource;
+    if (this.group)   { s += "/" + this.group;   }
+    if (this.version) { s += "/" + this.version; }
+    return s;
+  };
+  // primaryResource() returns the resource with any subresources removed
+  ResourceGroupVersion.prototype.primaryResource = function() {
+    if (!this.resource) { return ""; }
+    var i = this.resource.indexOf('/');
+    if (i === -1) { return this.resource; }
+    return this.resource.substring(0,i);
+  };
+  // subresources() returns a (possibly empty) list of subresource segments
+  ResourceGroupVersion.prototype.subresources = function() {
+    var segments = (this.resource || '').split("/");
+    segments.shift();
+    return segments;
+  };
+  // equals() returns true if the given resource, group, and version match.
+  // If omitted, group and version are not compared.
+  ResourceGroupVersion.prototype.equals = function(resource, group, version) {
+    if (this.resource !== resource) { return false; }
+    if (arguments.length === 1)     { return true;  }
+    if (this.group !== group)       { return false; }
+    if (arguments.length === 2)     { return true;  }
+    if (this.version !== version)   { return false; }
+    return true;
+  };
+
+  return ResourceGroupVersion;
+})
 .factory('APIService', function(API_CFG,
                                 APIS_CFG,
                                 AuthService,
@@ -250,7 +253,8 @@ angular.module('openshiftCommonServices')
                                 $q,
                                 $http,
                                 $filter,
-                                $window) {
+                                $window,
+                                ResourceGroupVersion) {
   // Set the default api versions the console will use if otherwise unspecified
   var defaultVersion = {
     "":           "v1",

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -1749,46 +1749,49 @@ angular.module("openshiftCommonServices")
   });
 ;'use strict';
 
-// ResourceGroupVersion represents a fully qualified resource
-function ResourceGroupVersion(resource, group, version) {
-  this.resource = resource;
-  this.group    = group;
-  this.version  = version;
-  return this;
-}
-// toString() includes the group and version information if present
-ResourceGroupVersion.prototype.toString = function() {
-  var s = this.resource;
-  if (this.group)   { s += "/" + this.group;   }
-  if (this.version) { s += "/" + this.version; }
-  return s;
-};
-// primaryResource() returns the resource with any subresources removed
-ResourceGroupVersion.prototype.primaryResource = function() {
-  if (!this.resource) { return ""; }
-  var i = this.resource.indexOf('/');
-  if (i === -1) { return this.resource; }
-  return this.resource.substring(0,i);
-};
-// subresources() returns a (possibly empty) list of subresource segments
-ResourceGroupVersion.prototype.subresources = function() {
-  var segments = (this.resource || '').split("/");
-  segments.shift();
-  return segments;
-};
-// equals() returns true if the given resource, group, and version match.
-// If omitted, group and version are not compared.
-ResourceGroupVersion.prototype.equals = function(resource, group, version) {
-  if (this.resource !== resource) { return false; }
-  if (arguments.length === 1)     { return true;  }
-  if (this.group !== group)       { return false; }
-  if (arguments.length === 2)     { return true;  }
-  if (this.version !== version)   { return false; }
-  return true;
-};
-
 angular.module('openshiftCommonServices')
-.factory('APIService', ["API_CFG", "APIS_CFG", "AuthService", "Constants", "Logger", "$q", "$http", "$filter", "$window", function(API_CFG,
+.factory('ResourceGroupVersion', function() {
+  // ResourceGroupVersion represents a fully qualified resource
+  function ResourceGroupVersion(resource, group, version) {
+    this.resource = resource;
+    this.group    = group;
+    this.version  = version;
+    return this;
+  }
+  // toString() includes the group and version information if present
+  ResourceGroupVersion.prototype.toString = function() {
+    var s = this.resource;
+    if (this.group)   { s += "/" + this.group;   }
+    if (this.version) { s += "/" + this.version; }
+    return s;
+  };
+  // primaryResource() returns the resource with any subresources removed
+  ResourceGroupVersion.prototype.primaryResource = function() {
+    if (!this.resource) { return ""; }
+    var i = this.resource.indexOf('/');
+    if (i === -1) { return this.resource; }
+    return this.resource.substring(0,i);
+  };
+  // subresources() returns a (possibly empty) list of subresource segments
+  ResourceGroupVersion.prototype.subresources = function() {
+    var segments = (this.resource || '').split("/");
+    segments.shift();
+    return segments;
+  };
+  // equals() returns true if the given resource, group, and version match.
+  // If omitted, group and version are not compared.
+  ResourceGroupVersion.prototype.equals = function(resource, group, version) {
+    if (this.resource !== resource) { return false; }
+    if (arguments.length === 1)     { return true;  }
+    if (this.group !== group)       { return false; }
+    if (arguments.length === 2)     { return true;  }
+    if (this.version !== version)   { return false; }
+    return true;
+  };
+
+  return ResourceGroupVersion;
+})
+.factory('APIService', ["API_CFG", "APIS_CFG", "AuthService", "Constants", "Logger", "$q", "$http", "$filter", "$window", "ResourceGroupVersion", function(API_CFG,
                                 APIS_CFG,
                                 AuthService,
                                 Constants,
@@ -1796,7 +1799,8 @@ angular.module('openshiftCommonServices')
                                 $q,
                                 $http,
                                 $filter,
-                                $window) {
+                                $window,
+                                ResourceGroupVersion) {
   // Set the default api versions the console will use if otherwise unspecified
   var defaultVersion = {
     "":           "v1",

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1,7 +1,3 @@
-function ResourceGroupVersion(resource, group, version) {
-return this.resource = resource, this.group = group, this.version = version, this;
-}
-
 angular.module("openshiftCommonServices", [ "ab-base64" ]).config([ "AuthServiceProvider", function(AuthServiceProvider) {
 AuthServiceProvider.UserStore("MemoryUserStore");
 } ]).constant("API_CFG", _.get(window.OPENSHIFT_CONFIG, "api", {})).constant("APIS_CFG", _.get(window.OPENSHIFT_CONFIG, "apis", {})).constant("AUTH_CFG", _.get(window.OPENSHIFT_CONFIG, "auth", {})).config([ "$httpProvider", "AuthServiceProvider", "RedirectLoginServiceProvider", "AUTH_CFG", function($httpProvider, AuthServiceProvider, RedirectLoginServiceProvider, AUTH_CFG) {
@@ -682,7 +678,11 @@ var key = alertHiddenKey(alertID, namespace);
 localStorage.setItem(key, "true");
 }
 };
-}), ResourceGroupVersion.prototype.toString = function() {
+}), angular.module("openshiftCommonServices").factory("ResourceGroupVersion", function() {
+function ResourceGroupVersion(resource, group, version) {
+return this.resource = resource, this.group = group, this.version = version, this;
+}
+return ResourceGroupVersion.prototype.toString = function() {
 var s = this.resource;
 return this.group && (s += "/" + this.group), this.version && (s += "/" + this.version), s;
 }, ResourceGroupVersion.prototype.primaryResource = function() {
@@ -694,7 +694,8 @@ var segments = (this.resource || "").split("/");
 return segments.shift(), segments;
 }, ResourceGroupVersion.prototype.equals = function(resource, group, version) {
 return this.resource !== resource ? !1 :1 === arguments.length ? !0 :this.group !== group ? !1 :2 === arguments.length ? !0 :this.version !== version ? !1 :!0;
-}, angular.module("openshiftCommonServices").factory("APIService", [ "API_CFG", "APIS_CFG", "AuthService", "Constants", "Logger", "$q", "$http", "$filter", "$window", function(API_CFG, APIS_CFG, AuthService, Constants, Logger, $q, $http, $filter, $window) {
+}, ResourceGroupVersion;
+}).factory("APIService", [ "API_CFG", "APIS_CFG", "AuthService", "Constants", "Logger", "$q", "$http", "$filter", "$window", "ResourceGroupVersion", function(API_CFG, APIS_CFG, AuthService, Constants, Logger, $q, $http, $filter, $window, ResourceGroupVersion) {
 function normalizeResource(resource) {
 if (!resource) return resource;
 var i = resource.indexOf("/");

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1,351 +1,356 @@
 'use strict';
 
-// ResourceGroupVersion represents a fully qualified resource
-function ResourceGroupVersion(resource, group, version) {
-  this.resource = resource;
-  this.group    = group;
-  this.version  = version;
-  return this;
-}
-// toString() includes the group and version information if present
-ResourceGroupVersion.prototype.toString = function() {
-  var s = this.resource;
-  if (this.group)   { s += "/" + this.group;   }
-  if (this.version) { s += "/" + this.version; }
-  return s;
-};
-// primaryResource() returns the resource with any subresources removed
-ResourceGroupVersion.prototype.primaryResource = function() {
-  if (!this.resource) { return ""; }
-  var i = this.resource.indexOf('/');
-  if (i === -1) { return this.resource; }
-  return this.resource.substring(0,i);
-};
-// subresources() returns a (possibly empty) list of subresource segments
-ResourceGroupVersion.prototype.subresources = function() {
-  var segments = (this.resource || '').split("/");
-  segments.shift();
-  return segments;
-};
-// equals() returns true if the given resource, group, and version match.
-// If omitted, group and version are not compared.
-ResourceGroupVersion.prototype.equals = function(resource, group, version) {
-  if (this.resource !== resource) { return false; }
-  if (arguments.length === 1)     { return true;  }
-  if (this.group !== group)       { return false; }
-  if (arguments.length === 2)     { return true;  }
-  if (this.version !== version)   { return false; }
-  return true;
-};
+(function() {
 
-angular.module('openshiftCommonServices')
-.factory('APIService', function(API_CFG,
-                                APIS_CFG,
-                                AuthService,
-                                Constants,
-                                Logger,
-                                $q,
-                                $http,
-                                $filter,
-                                $window) {
-  // Set the default api versions the console will use if otherwise unspecified
-  var defaultVersion = {
-    "":           "v1",
-    "extensions": "v1beta1"
-  };
-
-  // toResourceGroupVersion() returns a ResourceGroupVersion.
-  // If resource is already a ResourceGroupVersion, returns itself.
-  //
-  // if r is a string, the empty group and default version for the empty group are assumed.
-  //
-  // if r is an object, the resource, group, and version attributes are read.
-  // a missing group attribute defaults to the legacy group.
-  // a missing version attribute defaults to the default version for the group, or undefined if the group is unknown.
-  //
-  // if r is already a ResourceGroupVersion, it is returned as-is
-  var toResourceGroupVersion = function(r) {
-    if (r instanceof ResourceGroupVersion) {
-      return r;
-    }
-    var resource, group, version;
-    if (angular.isString(r)) {
-      resource = normalizeResource(r);
-      group = '';
-      version = defaultVersion[group];
-    } else if (r && r.resource) {
-      resource = normalizeResource(r.resource);
-      group = r.group || '';
-      version = r.version || defaultVersion[group] || _.get(APIS_CFG, ["groups", group, "preferredVersion"]);
-    }
-    return new ResourceGroupVersion(resource, group, version);
-  };
-
-  // normalizeResource lowercases the first segment of the given resource. subresources can be case-sensitive.
-  function normalizeResource(resource) {
-    if (!resource) {
-      return resource;
-    }
-    var i = resource.indexOf('/');
-    if (i === -1) {
-      return resource.toLowerCase();
-    }
-    return resource.substring(0, i).toLowerCase() + resource.substring(i);
+  // ResourceGroupVersion represents a fully qualified resource
+  function ResourceGroupVersion(resource, group, version) {
+    this.resource = resource;
+    this.group    = group;
+    this.version  = version;
+    return this;
   }
+  // toString() includes the group and version information if present
+  ResourceGroupVersion.prototype.toString = function() {
+    var s = this.resource;
+    if (this.group)   { s += "/" + this.group;   }
+    if (this.version) { s += "/" + this.version; }
+    return s;
+  };
+  // primaryResource() returns the resource with any subresources removed
+  ResourceGroupVersion.prototype.primaryResource = function() {
+    if (!this.resource) { return ""; }
+    var i = this.resource.indexOf('/');
+    if (i === -1) { return this.resource; }
+    return this.resource.substring(0,i);
+  };
+  // subresources() returns a (possibly empty) list of subresource segments
+  ResourceGroupVersion.prototype.subresources = function() {
+    var segments = (this.resource || '').split("/");
+    segments.shift();
+    return segments;
+  };
+  // equals() returns true if the given resource, group, and version match.
+  // If omitted, group and version are not compared.
+  ResourceGroupVersion.prototype.equals = function(resource, group, version) {
+    if (this.resource !== resource) { return false; }
+    if (arguments.length === 1)     { return true;  }
+    if (this.group !== group)       { return false; }
+    if (arguments.length === 2)     { return true;  }
+    if (this.version !== version)   { return false; }
+    return true;
+  };
 
-  // port of group_version.go#ParseGroupVersion
-  var parseGroupVersion = function(apiVersion) {
-    if (!apiVersion) {
-      return undefined;
-    }
-    var parts = apiVersion.split("/");
-    if (parts.length === 1) {
-      if (parts[0] === "v1") {
-        return {group: '', version: parts[0]};
+
+  angular.module('openshiftCommonServices')
+  .factory('APIService', function(API_CFG,
+                                  APIS_CFG,
+                                  AuthService,
+                                  Constants,
+                                  Logger,
+                                  $q,
+                                  $http,
+                                  $filter,
+                                  $window) {
+    // Set the default api versions the console will use if otherwise unspecified
+    var defaultVersion = {
+      "":           "v1",
+      "extensions": "v1beta1"
+    };
+
+    // toResourceGroupVersion() returns a ResourceGroupVersion.
+    // If resource is already a ResourceGroupVersion, returns itself.
+    //
+    // if r is a string, the empty group and default version for the empty group are assumed.
+    //
+    // if r is an object, the resource, group, and version attributes are read.
+    // a missing group attribute defaults to the legacy group.
+    // a missing version attribute defaults to the default version for the group, or undefined if the group is unknown.
+    //
+    // if r is already a ResourceGroupVersion, it is returned as-is
+    var toResourceGroupVersion = function(r) {
+      if (r instanceof ResourceGroupVersion) {
+        return r;
       }
-      return {group: parts[0], version: ''};
-    }
-    if (parts.length === 2) {
-      return {group:parts[0], version: parts[1]};
-    }
-    Logger.warn('Invalid apiVersion "' + apiVersion + '"');
-    return undefined;
-  };
+      var resource, group, version;
+      if (angular.isString(r)) {
+        resource = normalizeResource(r);
+        group = '';
+        version = defaultVersion[group];
+      } else if (r && r.resource) {
+        resource = normalizeResource(r.resource);
+        group = r.group || '';
+        version = r.version || defaultVersion[group] || _.get(APIS_CFG, ["groups", group, "preferredVersion"]);
+      }
+      return new ResourceGroupVersion(resource, group, version);
+    };
 
-  var objectToResourceGroupVersion = function(apiObject) {
-    if (!apiObject || !apiObject.kind || !apiObject.apiVersion) {
-      return undefined;
-    }
-    var resource = kindToResource(apiObject.kind);
-    if (!resource) {
-      return undefined;
-    }
-    var groupVersion = parseGroupVersion(apiObject.apiVersion);
-    if (!groupVersion) {
-      return undefined;
-    }
-    return new ResourceGroupVersion(resource, groupVersion.group, groupVersion.version);
-  };
-
-  // deriveTargetResource figures out the fully qualified destination to submit the object to.
-  // if resource is a string, and the object's kind matches the resource, the object's group/version are used.
-  // if resource is a ResourceGroupVersion, and the object's kind and group match, the object's version is used.
-  // otherwise, resource is used as-is.
-  var deriveTargetResource = function(resource, object) {
-    if (!resource || !object) {
-      return undefined;
-    }
-    var objectResource = kindToResource(object.kind);
-    var objectGroupVersion = parseGroupVersion(object.apiVersion);
-    var resourceGroupVersion = toResourceGroupVersion(resource);
-    if (!objectResource || !objectGroupVersion || !resourceGroupVersion) {
-      return undefined;
+    // normalizeResource lowercases the first segment of the given resource. subresources can be case-sensitive.
+    function normalizeResource(resource) {
+      if (!resource) {
+        return resource;
+      }
+      var i = resource.indexOf('/');
+      if (i === -1) {
+        return resource.toLowerCase();
+      }
+      return resource.substring(0, i).toLowerCase() + resource.substring(i);
     }
 
-    // We specified something like "pods"
-    if (angular.isString(resource)) {
-      // If the object had a matching kind {"kind":"Pod","apiVersion":"v1"}, use the group/version from the object
-      if (resourceGroupVersion.equals(objectResource)) {
-        resourceGroupVersion.group = objectGroupVersion.group;
+    // port of group_version.go#ParseGroupVersion
+    var parseGroupVersion = function(apiVersion) {
+      if (!apiVersion) {
+        return undefined;
+      }
+      var parts = apiVersion.split("/");
+      if (parts.length === 1) {
+        if (parts[0] === "v1") {
+          return {group: '', version: parts[0]};
+        }
+        return {group: parts[0], version: ''};
+      }
+      if (parts.length === 2) {
+        return {group:parts[0], version: parts[1]};
+      }
+      Logger.warn('Invalid apiVersion "' + apiVersion + '"');
+      return undefined;
+    };
+
+    var objectToResourceGroupVersion = function(apiObject) {
+      if (!apiObject || !apiObject.kind || !apiObject.apiVersion) {
+        return undefined;
+      }
+      var resource = kindToResource(apiObject.kind);
+      if (!resource) {
+        return undefined;
+      }
+      var groupVersion = parseGroupVersion(apiObject.apiVersion);
+      if (!groupVersion) {
+        return undefined;
+      }
+      return new ResourceGroupVersion(resource, groupVersion.group, groupVersion.version);
+    };
+
+    // deriveTargetResource figures out the fully qualified destination to submit the object to.
+    // if resource is a string, and the object's kind matches the resource, the object's group/version are used.
+    // if resource is a ResourceGroupVersion, and the object's kind and group match, the object's version is used.
+    // otherwise, resource is used as-is.
+    var deriveTargetResource = function(resource, object) {
+      if (!resource || !object) {
+        return undefined;
+      }
+      var objectResource = kindToResource(object.kind);
+      var objectGroupVersion = parseGroupVersion(object.apiVersion);
+      var resourceGroupVersion = toResourceGroupVersion(resource);
+      if (!objectResource || !objectGroupVersion || !resourceGroupVersion) {
+        return undefined;
+      }
+
+      // We specified something like "pods"
+      if (angular.isString(resource)) {
+        // If the object had a matching kind {"kind":"Pod","apiVersion":"v1"}, use the group/version from the object
+        if (resourceGroupVersion.equals(objectResource)) {
+          resourceGroupVersion.group = objectGroupVersion.group;
+          resourceGroupVersion.version = objectGroupVersion.version;
+        }
+        return resourceGroupVersion;
+      }
+
+      // If the resource was already a fully specified object,
+      // require the group to match as well before taking the version from the object
+      if (resourceGroupVersion.equals(objectResource, objectGroupVersion.group)) {
         resourceGroupVersion.version = objectGroupVersion.version;
       }
       return resourceGroupVersion;
+    };
+
+    // port of restmapper.go#kindToResource
+    // humanize will add spaces between words in the resource
+    function kindToResource(kindStr, humanize) {
+      if (!kindStr) {
+        return "";
+      }
+      var resource = kindStr;
+      if (humanize) {
+        var humanizeKind = $filter("humanizeKind");
+        resource = humanizeKind(resource);
+      }
+      resource = String(resource).toLowerCase();
+      if (resource === 'endpoints' || resource === 'securitycontextconstraints') {
+        // no-op, plural is the singular
+      }
+      else if (resource[resource.length-1] === 's') {
+        resource = resource + 'es';
+      }
+      else if (resource[resource.length-1] === 'y') {
+        resource = resource.substring(0, resource.length-1) + 'ies';
+      }
+      else {
+        resource = resource + 's';
+      }
+
+      return resource;
     }
 
-    // If the resource was already a fully specified object,
-    // require the group to match as well before taking the version from the object
-    if (resourceGroupVersion.equals(objectResource, objectGroupVersion.group)) {
-      resourceGroupVersion.version = objectGroupVersion.version;
-    }
-    return resourceGroupVersion;
-  };
-
-  // port of restmapper.go#kindToResource
-  // humanize will add spaces between words in the resource
-  function kindToResource(kind, humanize) {
-    if (!kind) {
-      return "";
-    }
-    var resource = kind;
-    if (humanize) {
-      var humanizeKind = $filter("humanizeKind");
-      resource = humanizeKind(resource);
-    }
-    resource = String(resource).toLowerCase();
-    if (resource === 'endpoints' || resource === 'securitycontextconstraints') {
-      // no-op, plural is the singular
-    }
-    else if (resource[resource.length-1] === 's') {
-      resource = resource + 'es';
-    }
-    else if (resource[resource.length-1] === 'y') {
-      resource = resource.substring(0, resource.length-1) + 'ies';
-    }
-    else {
-      resource = resource + 's';
-    }
-
-    return resource;
-  }
-
-  // apiInfo returns the host/port, prefix, group, and version for the given resource,
-  // or undefined if the specified resource/group/version is known not to exist.
-  var apiInfo = function(resource) {
-    // If API discovery had any failures, calls to api info should redirect to the error page
-    if (APIS_CFG.API_DISCOVERY_ERRORS) {
-      var possibleCertFailure  = _.every(APIS_CFG.API_DISCOVERY_ERRORS, function(error){
-        return _.get(error, "data.status") === 0;
-      });
-      if (possibleCertFailure && !AuthService.isLoggedIn()) {
-        // will trigger a login flow which will redirect to the api server
-        AuthService.withUser();
+    // apiInfo returns the host/port, prefix, group, and version for the given resource,
+    // or undefined if the specified resource/group/version is known not to exist.
+    var apiInfo = function(resource) {
+      // If API discovery had any failures, calls to api info should redirect to the error page
+      if (APIS_CFG.API_DISCOVERY_ERRORS) {
+        var possibleCertFailure  = _.every(APIS_CFG.API_DISCOVERY_ERRORS, function(error){
+          return _.get(error, "data.status") === 0;
+        });
+        if (possibleCertFailure && !AuthService.isLoggedIn()) {
+          // will trigger a login flow which will redirect to the api server
+          AuthService.withUser();
+          return;
+        }
+        // Otherwise go to the error page, the server might be down.  Can't use Navigate.toErrorPage or it will create a circular dependency
+        $window.location.href = URI('error').query({
+          error_description: "Unable to load details about the server. If the problem continues, please contact your system administrator.",
+          error: "API_DISCOVERY"
+        }).toString();
         return;
       }
-      // Otherwise go to the error page, the server might be down.  Can't use Navigate.toErrorPage or it will create a circular dependency
-      $window.location.href = URI('error').query({
-        error_description: "Unable to load details about the server. If the problem continues, please contact your system administrator.",
-        error: "API_DISCOVERY"
-      }).toString();
-      return;
-    }
 
-    resource = toResourceGroupVersion(resource);
-    var primaryResource = resource.primaryResource();
-    var discoveredResource;
-    // API info for resources in an API group, if the resource was not found during discovery return undefined
-    if (resource.group) {
-      discoveredResource = _.get(APIS_CFG, ["groups", resource.group, "versions", resource.version, "resources", primaryResource]);
-      if (!discoveredResource) {
-        return undefined;
+      resource = toResourceGroupVersion(resource);
+      var primaryResource = resource.primaryResource();
+      var discoveredResource;
+      // API info for resources in an API group, if the resource was not found during discovery return undefined
+      if (resource.group) {
+        discoveredResource = _.get(APIS_CFG, ["groups", resource.group, "versions", resource.version, "resources", primaryResource]);
+        if (!discoveredResource) {
+          return undefined;
+        }
+        var hostPrefixObj = _.get(APIS_CFG, ["groups", resource.group, 'hostPrefix']) || APIS_CFG;
+        return {
+          protocol: hostPrefixObj.protocol,
+          hostPort: hostPrefixObj.hostPort,
+          prefix:   hostPrefixObj.prefix,
+          group:    resource.group,
+          version:  resource.version,
+          namespaced: discoveredResource.namespaced
+        };
       }
-      var hostPrefixObj = _.get(APIS_CFG, ["groups", resource.group, 'hostPrefix']) || APIS_CFG;
-      return {
-        protocol: hostPrefixObj.protocol,
-        hostPort: hostPrefixObj.hostPort,
-        prefix:   hostPrefixObj.prefix,
-        group:    resource.group,
-        version:  resource.version,
-        namespaced: discoveredResource.namespaced
-      };
-    }
 
-    // Resources without an API group could be legacy k8s or origin resources.
-    // Scan through resources to determine which this is.
-    var api;
-    for (var apiName in API_CFG) {
-      api = API_CFG[apiName];
-      discoveredResource = _.get(api, ["resources", resource.version, primaryResource]);
-      if (!discoveredResource) {
-        continue;
+      // Resources without an API group could be legacy k8s or origin resources.
+      // Scan through resources to determine which this is.
+      var api;
+      for (var apiName in API_CFG) {
+        api = API_CFG[apiName];
+        discoveredResource = _.get(api, ["resources", resource.version, primaryResource]);
+        if (!discoveredResource) {
+          continue;
+        }
+        return {
+          hostPort: api.hostPort,
+          prefix:   api.prefix,
+          version:  resource.version,
+          namespaced: discoveredResource.namespaced
+        };
       }
-      return {
-        hostPort: api.hostPort,
-        prefix:   api.prefix,
-        version:  resource.version,
-        namespaced: discoveredResource.namespaced
-      };
-    }
-    return undefined;
-  };
+      return undefined;
+    };
 
-  var invalidObjectKindOrVersion = function(apiObject) {
-    var kind = "<none>";
-    var version = "<none>";
-    if (apiObject && apiObject.kind)       { kind    = apiObject.kind;       }
-    if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
-    return "Invalid kind ("+kind+") or API version ("+version+")";
-  };
-  var unsupportedObjectKindOrVersion = function(apiObject) {
-    var kind = "<none>";
-    var version = "<none>";
-    if (apiObject && apiObject.kind)       { kind    = apiObject.kind;       }
-    if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
-    return "The API version "+version+" for kind " + kind + " is not supported by this server";
-  };
+    var invalidObjectKindOrVersion = function(apiObject) {
+      var kind = "<none>";
+      var version = "<none>";
+      if (apiObject && apiObject.kind)       { kind    = apiObject.kind;       }
+      if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
+      return "Invalid kind ("+kind+") or API version ("+version+")";
+    };
+    var unsupportedObjectKindOrVersion = function(apiObject) {
+      var kind = "<none>";
+      var version = "<none>";
+      if (apiObject && apiObject.kind)       { kind    = apiObject.kind;       }
+      if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
+      return "The API version "+version+" for kind " + kind + " is not supported by this server";
+    };
 
-  // Returns an array of available kinds, including their group
-  var calculateAvailableKinds = function(includeClusterScoped) {
-    var kinds = [];
-    var rejectedKinds = _.map(Constants.AVAILABLE_KINDS_BLACKLIST, function(kind) {
-      return _.isString(kind) ?
-              { kind: kind, group: '' } :
-              kind;
-    });
+    // Returns an array of available kinds, including their group
+    var calculateAvailableKinds = function(includeClusterScoped) {
+      var kinds = [];
+      var rejectedKinds = _.map(Constants.AVAILABLE_KINDS_BLACKLIST, function(kind) {
+        return _.isString(kind) ?
+                { kind: kind, group: '' } :
+                kind;
+      });
 
 
-    // ignore the legacy openshift kinds, these have been migrated to api groups
-    _.each(_.pick(API_CFG, function(value, key) {
-      return key !== 'openshift';
-    }), function(api) {
-      _.each(api.resources.v1, function(resource) {
-        if (resource.namespaced || includeClusterScoped) {
+      // ignore the legacy openshift kinds, these have been migrated to api groups
+      _.each(_.pick(API_CFG, function(value, key) {
+        return key !== 'openshift';
+      }), function(api) {
+        _.each(api.resources.v1, function(resource) {
+          if (resource.namespaced || includeClusterScoped) {
+            // Exclude subresources and any rejected kinds
+            if (_.contains(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
+              return;
+            }
+
+            kinds.push({
+              kind: resource.kind,
+              group:  ''
+            });
+          }
+        });
+      });
+
+     // Kinds under api groups
+      _.each(APIS_CFG.groups, function(group) {
+        // Use the console's default version first, and the server's preferred version second
+        var preferredVersion = defaultVersion[group.name] || group.preferredVersion;
+        _.each(group.versions[preferredVersion].resources, function(resource) {
           // Exclude subresources and any rejected kinds
-          if (_.contains(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
+          if (_.contains(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
             return;
           }
 
-          kinds.push({
-            kind: resource.kind,
-            group:  ''
-          });
-        }
+          // Exclude duplicate kinds we know about that map to the same storage as another group/kind
+          // This is unusual, so we are special casing these
+          if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler" ||
+              group.name === "batch" && resource.kind === "Job"
+          ) {
+            return;
+          }
+
+          if (resource.namespaced || includeClusterScoped) {
+            kinds.push({
+              kind: resource.kind,
+              group: group.name
+            });
+          }
+        });
       });
-    });
 
-   // Kinds under api groups
-    _.each(APIS_CFG.groups, function(group) {
-      // Use the console's default version first, and the server's preferred version second
-      var preferredVersion = defaultVersion[group.name] || group.preferredVersion;
-      _.each(group.versions[preferredVersion].resources, function(resource) {
-        // Exclude subresources and any rejected kinds
-        if (_.contains(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
-          return;
-        }
-
-        // Exclude duplicate kinds we know about that map to the same storage as another group/kind
-        // This is unusual, so we are special casing these
-        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler" ||
-            group.name === "batch" && resource.kind === "Job"
-        ) {
-          return;
-        }
-
-        if (resource.namespaced || includeClusterScoped) {
-          kinds.push({
-            kind: resource.kind,
-            group: group.name
-          });
-        }
+      return _.uniq(kinds, false, function(value) {
+        return value.group + "/" + value.kind;
       });
-    });
+    };
 
-    return _.uniq(kinds, false, function(value) {
-      return value.group + "/" + value.kind;
-    });
-  };
+    var namespacedKinds = calculateAvailableKinds(false);
+    var allKinds = calculateAvailableKinds(true);
 
-  var namespacedKinds = calculateAvailableKinds(false);
-  var allKinds = calculateAvailableKinds(true);
+    var availableKinds = function(includeClusterScoped) {
+      return includeClusterScoped ? allKinds : namespacedKinds;
+    };
 
-  var availableKinds = function(includeClusterScoped) {
-    return includeClusterScoped ? allKinds : namespacedKinds;
-  };
+    return {
+      toResourceGroupVersion: toResourceGroupVersion,
 
-  return {
-    toResourceGroupVersion: toResourceGroupVersion,
+      parseGroupVersion: parseGroupVersion,
 
-    parseGroupVersion: parseGroupVersion,
+      objectToResourceGroupVersion: objectToResourceGroupVersion,
 
-    objectToResourceGroupVersion: objectToResourceGroupVersion,
+      deriveTargetResource: deriveTargetResource,
 
-    deriveTargetResource: deriveTargetResource,
+      kindToResource: kindToResource,
 
-    kindToResource: kindToResource,
+      apiInfo: apiInfo,
 
-    apiInfo: apiInfo,
+      invalidObjectKindOrVersion: invalidObjectKindOrVersion,
+      unsupportedObjectKindOrVersion: unsupportedObjectKindOrVersion,
+      availableKinds: availableKinds
+    };
+  });
 
-    invalidObjectKindOrVersion: invalidObjectKindOrVersion,
-    unsupportedObjectKindOrVersion: unsupportedObjectKindOrVersion,
-    availableKinds: availableKinds
-  };
-});
+})();

--- a/test/spec/services/apiServiceSpec.js
+++ b/test/spec/services/apiServiceSpec.js
@@ -130,7 +130,7 @@ describe("APIService", function() {
       ["Policy",          "policies"],
       // special cases
       ["Endpoints",                  "endpoints"],
-      ["SecurityContextConstraints", "securitycontextconstraints"],
+      ["SecurityContextConstraints", "securitycontextconstraints"]
     ];
     angular.forEach(tc, _.spread(function(kind, resource) {
       it('should result in ' + JSON.stringify(resource) + ' when called with ' + JSON.stringify(kind), function() {
@@ -310,7 +310,7 @@ describe("APIService", function() {
     it('should not return kinds from the AVAILABLE_KINDS_BLACKLIST', function() {
       var allKinds = APIService.availableKinds(true);
       // calculateAvailableKinds will transform strings form AVAILABLE_KINDS_BLACKLIST
-      // into objects in this same way. 
+      // into objects in this same way.
       var blacklist = _.map(window.OPENSHIFT_CONSTANTS.AVAILABLE_KINDS_BLACKLIST, function(kind) {
         return _.isString(kind) ?
                 { kind: kind, group: '' } :


### PR DESCRIPTION
This just wraps the constructor function in a service so we eliminate the global.