### PR TITLE
Adding line-clamp mixin

### DIFF
--- a/dist/less/_mixins.less
+++ b/dist/less/_mixins.less
@@ -1,5 +1,17 @@
 // origin-web-common mixins
 
+// DESCRIPTION: Limits text to x number of lines and adds an ellipsis to the
+// end of the truncated line in webkit-based browsers
+.line-clamp(@lines: 1, @line-height: @line-height-base) {
+  display: -webkit-box;
+  line-height: @line-height;
+  max-height: (1em * @line-height * @lines);
+  overflow: hidden;
+  padding: 0 !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: @lines;
+}
+
 // word-break and word-break-all test cases http://codepen.io/sg00dwin/pen/WwKMmP
 //
 // DESCRIPTION: Breaks long non-breaking strings within a div or a flexed item that is within a flex container

--- a/src/styles/_mixins.less
+++ b/src/styles/_mixins.less
@@ -1,5 +1,17 @@
 // origin-web-common mixins
 
+// DESCRIPTION: Limits text to x number of lines and adds an ellipsis to the
+// end of the truncated line in webkit-based browsers
+.line-clamp(@lines: 1, @line-height: @line-height-base) {
+  display: -webkit-box;
+  line-height: @line-height;
+  max-height: (1em * @line-height * @lines);
+  overflow: hidden;
+  padding: 0 !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: @lines;
+}
+
 // word-break and word-break-all test cases http://codepen.io/sg00dwin/pen/WwKMmP
 //
 // DESCRIPTION: Breaks long non-breaking strings within a div or a flexed item that is within a flex container


### PR DESCRIPTION
The mixin was created as part of https://github.com/openshift/origin-web-catalog/pull/230, but it should really live in common so that it can be used in both the console and the catalog.  I will update https://github.com/openshift/origin-web-catalog/pull/230 to remove this mixin from that pr once this PR lands and catalog can be updated to make use of it.