### PR TITLE
Drop PhantomJS & use Firefox for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache:
   directories:
   - node_modules
   - bower_components
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 before_script:
   - make build
 script:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,10 @@ module.exports = function (grunt) {
         unit: {
           configFile: 'test/karma.conf.js',
           singleRun: true,
-          browsers: ['PhantomJS']
+          // grunt test --browsers=Chrome,Firefox,Safari
+          browsers: grunt.option('browsers') ?
+                      grunt.option('browsers').split(',') :
+                      ['Firefox']
         }
       },
       less: {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "karma-jasmine": "0.2.2",
     "karma-junit-reporter": "0.2.2",
     "karma-ng-html2js-preprocessor": "~0.1",
-    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-chrome-launcher": "^2.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1"
   },


### PR DESCRIPTION
Dropping PhantomJS & migrate to FF like we did in web-console.

@jwforres @jeff-phillips-18 