### PR TITLE
Add `.tile-click-prevent` class

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -885,9 +885,9 @@ angular.module('openshiftCommonUI')
       restrict: 'AC',
       link: function($scope, element) {
         $(element).click(function (evt) {
-          // Don't trigger tile target if the user clicked directly on a link or button inside the tile.
+          // Don't trigger tile target if the user clicked directly on a link or button inside the tile or any child of a .tile-click-prevent element.
           var t = $(evt.target);
-          if (t && (t.closest("a", element).length || t.closest("button", element).length)) {
+          if (t && (t.closest("a", element).length || t.closest("button", element).length) || t.closest(".tile-click-prevent", element).length) {
             return;
           }
           $('a.tile-target', element).trigger("click");

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -1056,9 +1056,9 @@ angular.module('openshiftCommonUI')
       restrict: 'AC',
       link: function($scope, element) {
         $(element).click(function (evt) {
-          // Don't trigger tile target if the user clicked directly on a link or button inside the tile.
+          // Don't trigger tile target if the user clicked directly on a link or button inside the tile or any child of a .tile-click-prevent element.
           var t = $(evt.target);
-          if (t && (t.closest("a", element).length || t.closest("button", element).length)) {
+          if (t && (t.closest("a", element).length || t.closest("button", element).length) || t.closest(".tile-click-prevent", element).length) {
             return;
           }
           $('a.tile-target', element).trigger("click");

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -339,7 +339,7 @@ restrict:"AC",
 link:function($scope, element) {
 $(element).click(function(evt) {
 var t = $(evt.target);
-t && (t.closest("a", element).length || t.closest("button", element).length) || $("a.tile-target", element).trigger("click");
+t && (t.closest("a", element).length || t.closest("button", element).length) || t.closest(".tile-click-prevent", element).length || $("a.tile-target", element).trigger("click");
 });
 }
 };

--- a/src/components/tile-click/tileClick.js
+++ b/src/components/tile-click/tileClick.js
@@ -6,9 +6,9 @@ angular.module('openshiftCommonUI')
       restrict: 'AC',
       link: function($scope, element) {
         $(element).click(function (evt) {
-          // Don't trigger tile target if the user clicked directly on a link or button inside the tile.
+          // Don't trigger tile target if the user clicked directly on a link or button inside the tile or any child of a .tile-click-prevent element.
           var t = $(evt.target);
-          if (t && (t.closest("a", element).length || t.closest("button", element).length)) {
+          if (t && (t.closest("a", element).length || t.closest("button", element).length) || t.closest(".tile-click-prevent", element).length) {
             return;
           }
           $('a.tile-target', element).trigger("click");


### PR DESCRIPTION
Add a `.tile-click-prevent` class to optionally block activating the tile click target on children of the tile click element.