### PR TITLE
Remove kind:jobs, group: batch from internal filter

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -518,9 +518,7 @@ angular.module('openshiftCommonServices')
 
         // Exclude duplicate kinds we know about that map to the same storage as another group/kind
         // This is unusual, so we are special casing these
-        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler" ||
-            group.name === "batch" && resource.kind === "Job"
-        ) {
+        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler") {
           return;
         }
 

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -2125,9 +2125,7 @@ angular.module('openshiftCommonServices')
 
         // Exclude duplicate kinds we know about that map to the same storage as another group/kind
         // This is unusual, so we are special casing these
-        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler" ||
-            group.name === "batch" && resource.kind === "Job"
-        ) {
+        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler") {
           return;
         }
 

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -844,7 +844,7 @@ _.each(group.versions[preferredVersion].resources, function(resource) {
 _.contains(resource.name, "/") || _.find(rejectedKinds, {
 kind:resource.kind,
 group:group.name
-}) || "extensions" === group.name && "HorizontalPodAutoscaler" === resource.kind || "batch" === group.name && "Job" === resource.kind || (resource.namespaced || includeClusterScoped) && kinds.push({
+}) || ("extensions" !== group.name || "HorizontalPodAutoscaler" !== resource.kind) && (resource.namespaced || includeClusterScoped) && kinds.push({
 kind:resource.kind,
 group:group.name
 });

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -315,9 +315,7 @@ angular.module('openshiftCommonServices')
 
         // Exclude duplicate kinds we know about that map to the same storage as another group/kind
         // This is unusual, so we are special casing these
-        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler" ||
-            group.name === "batch" && resource.kind === "Job"
-        ) {
+        if (group.name === "extensions" && resource.kind === "HorizontalPodAutoscaler") {
           return;
         }
 


### PR DESCRIPTION
Re [bugzilla #1457609](https://bugzilla.redhat.com/show_bug.cgi?id=1457609)
Remove kind:jobs, group: batch from internal filter in APIService.calculateAvailableKinds()

Pending verification from @mfojtik that the old `{kind:jobs, group:extensions}` from `v1beta1` has been eliminated.