### PR TITLE
[WIP] Remove unused AlertMessageService methods

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -173,7 +173,6 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
 
 angular.module("openshiftCommonServices")
   .service("AlertMessageService", function(){
-    var alerts = [];
     var alertHiddenKey = function(alertID, namespace) {
       if (!namespace) {
         return 'hide/alert/' + alertID;
@@ -182,15 +181,6 @@ angular.module("openshiftCommonServices")
       return 'hide/alert/' + namespace + '/' + alertID;
     };
     return {
-      addAlert: function(alert) {
-        alerts.push(alert);
-      },
-      getAlerts: function() {
-        return alerts;
-      },
-      clearAlerts: function() {
-        alerts = [];
-      },
       isAlertPermanentlyHidden: function(alertID, namespace) {
         var key = alertHiddenKey(alertID, namespace);
         return localStorage.getItem(key) === 'true';

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -1807,7 +1807,6 @@ angular.module('openshiftCommonUI')
 
 angular.module("openshiftCommonServices")
   .service("AlertMessageService", function(){
-    var alerts = [];
     var alertHiddenKey = function(alertID, namespace) {
       if (!namespace) {
         return 'hide/alert/' + alertID;
@@ -1816,15 +1815,6 @@ angular.module("openshiftCommonServices")
       return 'hide/alert/' + namespace + '/' + alertID;
     };
     return {
-      addAlert: function(alert) {
-        alerts.push(alert);
-      },
-      getAlerts: function() {
-        return alerts;
-      },
-      clearAlerts: function() {
-        alerts = [];
-      },
       isAlertPermanentlyHidden: function(alertID, namespace) {
         var key = alertHiddenKey(alertID, namespace);
         return localStorage.getItem(key) === 'true';

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -702,19 +702,10 @@ var status = result.status || error.status;
 return status ? "Status: " + status :"";
 };
 } ]), angular.module("openshiftCommonServices").service("AlertMessageService", function() {
-var alerts = [], alertHiddenKey = function(alertID, namespace) {
+var alertHiddenKey = function(alertID, namespace) {
 return namespace ? "hide/alert/" + namespace + "/" + alertID :"hide/alert/" + alertID;
 };
 return {
-addAlert:function(alert) {
-alerts.push(alert);
-},
-getAlerts:function() {
-return alerts;
-},
-clearAlerts:function() {
-alerts = [];
-},
 isAlertPermanentlyHidden:function(alertID, namespace) {
 var key = alertHiddenKey(alertID, namespace);
 return "true" === localStorage.getItem(key);

--- a/src/services/alertMessage.js
+++ b/src/services/alertMessage.js
@@ -2,7 +2,6 @@
 
 angular.module("openshiftCommonServices")
   .service("AlertMessageService", function(){
-    var alerts = [];
     var alertHiddenKey = function(alertID, namespace) {
       if (!namespace) {
         return 'hide/alert/' + alertID;
@@ -11,15 +10,6 @@ angular.module("openshiftCommonServices")
       return 'hide/alert/' + namespace + '/' + alertID;
     };
     return {
-      addAlert: function(alert) {
-        alerts.push(alert);
-      },
-      getAlerts: function() {
-        return alerts;
-      },
-      clearAlerts: function() {
-        alerts = [];
-      },
       isAlertPermanentlyHidden: function(alertID, namespace) {
         var key = alertHiddenKey(alertID, namespace);
         return localStorage.getItem(key) === 'true';


### PR DESCRIPTION
Remove addAlert(), getAlerts(), and clearAlerts(). These are no longer
used now that we use toast notifications for showing alerts just before
a page transition.

See https://github.com/openshift/origin-web-console/pull/1679
See https://github.com/openshift/origin-web-catalog/pull/278