### PR TITLE
Don't show both a toast and in-page alert for create project

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -534,7 +534,6 @@ angular.module("openshiftCommonUI")
     return {
       restrict: 'E',
       scope: {
-        alerts: '=',
         redirectAction: '&',
         onCancel: '&?',
         isDialog: '@'
@@ -547,9 +546,8 @@ angular.module("openshiftCommonUI")
 
         $scope.isDialog = $scope.isDialog === 'true';
 
-        var showAlert = function(name, alert) {
-          $scope.alerts[name] = alert;
-          NotificationsService.addNotification(alert);
+        var hideErrorNotifications = function() {
+          NotificationsService.hideNotification('create-project-error');
         };
 
         $scope.createProject = function() {
@@ -573,9 +571,9 @@ angular.module("openshiftCommonUI")
                 } else {
                   $location.path("project/" + encodeURIComponent(data.metadata.name) + "/create");
                 }
-                showAlert('created-project', {
+                NotificationsService.addNotification({
                   type: "success",
-                    message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
+                  message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
                 });
               }, function(result) {
                 $scope.disableInputs = false;
@@ -584,7 +582,11 @@ angular.module("openshiftCommonUI")
                   $scope.nameTaken = true;
                 } else {
                   var msg = data.message || 'An error occurred creating the project.';
-                  showAlert('error-creating-project', {type: 'error', message: msg});
+                  NotificationsService.addNotification({
+                    id: 'create-project-error',
+                    type: 'error',
+                    message: msg
+                  });
                 }
               });
           }
@@ -600,6 +602,8 @@ angular.module("openshiftCommonUI")
             $window.history.back();
           }
         };
+
+        $scope.$on("$destroy", hideErrorNotifications);
       },
     };
   });

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -705,7 +705,6 @@ angular.module("openshiftCommonUI")
     return {
       restrict: 'E',
       scope: {
-        alerts: '=',
         redirectAction: '&',
         onCancel: '&?',
         isDialog: '@'
@@ -718,9 +717,8 @@ angular.module("openshiftCommonUI")
 
         $scope.isDialog = $scope.isDialog === 'true';
 
-        var showAlert = function(name, alert) {
-          $scope.alerts[name] = alert;
-          NotificationsService.addNotification(alert);
+        var hideErrorNotifications = function() {
+          NotificationsService.hideNotification('create-project-error');
         };
 
         $scope.createProject = function() {
@@ -744,9 +742,9 @@ angular.module("openshiftCommonUI")
                 } else {
                   $location.path("project/" + encodeURIComponent(data.metadata.name) + "/create");
                 }
-                showAlert('created-project', {
+                NotificationsService.addNotification({
                   type: "success",
-                    message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
+                  message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
                 });
               }, function(result) {
                 $scope.disableInputs = false;
@@ -755,7 +753,11 @@ angular.module("openshiftCommonUI")
                   $scope.nameTaken = true;
                 } else {
                   var msg = data.message || 'An error occurred creating the project.';
-                  showAlert('error-creating-project', {type: 'error', message: msg});
+                  NotificationsService.addNotification({
+                    id: 'create-project-error',
+                    type: 'error',
+                    message: msg
+                  });
                 }
               });
           }
@@ -771,6 +773,8 @@ angular.module("openshiftCommonUI")
             $window.history.back();
           }
         };
+
+        $scope.$on("$destroy", hideErrorNotifications);
       }],
     };
   }]);

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -157,7 +157,6 @@ return humanizeKind(object.kind);
 return {
 restrict:"E",
 scope:{
-alerts:"=",
 redirectAction:"&",
 onCancel:"&?",
 isDialog:"@"
@@ -165,8 +164,8 @@ isDialog:"@"
 templateUrl:"src/components/create-project/createProject.html",
 controller:[ "$scope", "$filter", "$location", "DataService", "NotificationsService", "displayNameFilter", function($scope, $filter, $location, DataService, NotificationsService, displayNameFilter) {
 $scope.submitButtonLabel || ($scope.submitButtonLabel = "Create"), $scope.isDialog = "true" === $scope.isDialog;
-var showAlert = function(name, alert) {
-$scope.alerts[name] = alert, NotificationsService.addNotification(alert);
+var hideErrorNotifications = function() {
+NotificationsService.hideNotification("create-project-error");
 };
 $scope.createProject = function() {
 $scope.disableInputs = !0, $scope.createProjectForm.$valid && DataService.create("projectrequests", null, {
@@ -179,7 +178,7 @@ displayName:$scope.displayName,
 description:$scope.description
 }, $scope).then(function(data) {
 var cb = $scope.redirectAction();
-cb ? cb(encodeURIComponent(data.metadata.name)) :$location.path("project/" + encodeURIComponent(data.metadata.name) + "/create"), showAlert("created-project", {
+cb ? cb(encodeURIComponent(data.metadata.name)) :$location.path("project/" + encodeURIComponent(data.metadata.name) + "/create"), NotificationsService.addNotification({
 type:"success",
 message:"Project '" + displayNameFilter(data) + "' was successfully created."
 });
@@ -188,7 +187,8 @@ $scope.disableInputs = !1;
 var data = result.data || {};
 if ("AlreadyExists" === data.reason) $scope.nameTaken = !0; else {
 var msg = data.message || "An error occurred creating the project.";
-showAlert("error-creating-project", {
+NotificationsService.addNotification({
+id:"create-project-error",
 type:"error",
 message:msg
 });
@@ -199,7 +199,7 @@ if ($scope.onCancel) {
 var cb = $scope.onCancel();
 cb && cb();
 } else $window.history.back();
-};
+}, $scope.$on("$destroy", hideErrorNotifications);
 } ]
 };
 } ]), angular.module("openshiftCommonUI").directive("deleteProject", [ "$uibModal", "$location", "$filter", "$q", "hashSizeFilter", "APIService", "DataService", "NotificationsService", "Logger", function($uibModal, $location, $filter, $q, hashSizeFilter, APIService, DataService, NotificationsService, Logger) {

--- a/src/components/create-project/createProject.js
+++ b/src/components/create-project/createProject.js
@@ -6,7 +6,6 @@ angular.module("openshiftCommonUI")
     return {
       restrict: 'E',
       scope: {
-        alerts: '=',
         redirectAction: '&',
         onCancel: '&?',
         isDialog: '@'
@@ -19,9 +18,8 @@ angular.module("openshiftCommonUI")
 
         $scope.isDialog = $scope.isDialog === 'true';
 
-        var showAlert = function(name, alert) {
-          $scope.alerts[name] = alert;
-          NotificationsService.addNotification(alert);
+        var hideErrorNotifications = function() {
+          NotificationsService.hideNotification('create-project-error');
         };
 
         $scope.createProject = function() {
@@ -45,9 +43,9 @@ angular.module("openshiftCommonUI")
                 } else {
                   $location.path("project/" + encodeURIComponent(data.metadata.name) + "/create");
                 }
-                showAlert('created-project', {
+                NotificationsService.addNotification({
                   type: "success",
-                    message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
+                  message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
                 });
               }, function(result) {
                 $scope.disableInputs = false;
@@ -56,7 +54,11 @@ angular.module("openshiftCommonUI")
                   $scope.nameTaken = true;
                 } else {
                   var msg = data.message || 'An error occurred creating the project.';
-                  showAlert('error-creating-project', {type: 'error', message: msg});
+                  NotificationsService.addNotification({
+                    id: 'create-project-error',
+                    type: 'error',
+                    message: msg
+                  });
                 }
               });
           }
@@ -72,6 +74,8 @@ angular.module("openshiftCommonUI")
             $window.history.back();
           }
         };
+
+        $scope.$on("$destroy", hideErrorNotifications);
       },
     };
   });


### PR DESCRIPTION
@jwforres I want to make this change, but I'm worried it will break the console integration tests (on DCUT day no less). It looks like we'll show both an in-page alert and toast on create project errors, however.

@jeff-phillips-18 FYI