### PR TITLE
Fix for isWindowBelowBreakpoint checks

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -1902,15 +1902,18 @@ angular.module("openshiftCommonUI")
       isWindowBelowBreakpoint: function(size) {
         switch(size) {
           case WINDOW_SIZE_XXS:
-            return window.innerWidth < BREAKPOINTS.screenXsMin;
+            return false; // Nothing is below xxs
             break;
           case WINDOW_SIZE_XS:
-            return window.innerWidth < BREAKPOINTS.screenSmMin;
+            return window.innerWidth < BREAKPOINTS.screenXsMin;
             break;
           case WINDOW_SIZE_SM:
-            return window.innerWidth < BREAKPOINTS.screenMdMin;
+            return window.innerWidth < BREAKPOINTS.screenSmMin;
             break;
           case WINDOW_SIZE_MD:
+            return window.innerWidth < BREAKPOINTS.screenMdMin;
+            break;
+          case WINDOW_SIZE_LG:
             return window.innerWidth < BREAKPOINTS.screenLgMin;
             break;
           default:

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -5027,15 +5027,18 @@ angular.module("openshiftCommonUI")
       isWindowBelowBreakpoint: function(size) {
         switch(size) {
           case WINDOW_SIZE_XXS:
-            return window.innerWidth < BREAKPOINTS.screenXsMin;
+            return false; // Nothing is below xxs
             break;
           case WINDOW_SIZE_XS:
-            return window.innerWidth < BREAKPOINTS.screenSmMin;
+            return window.innerWidth < BREAKPOINTS.screenXsMin;
             break;
           case WINDOW_SIZE_SM:
-            return window.innerWidth < BREAKPOINTS.screenMdMin;
+            return window.innerWidth < BREAKPOINTS.screenSmMin;
             break;
           case WINDOW_SIZE_MD:
+            return window.innerWidth < BREAKPOINTS.screenMdMin;
+            break;
+          case WINDOW_SIZE_LG:
             return window.innerWidth < BREAKPOINTS.screenLgMin;
             break;
           default:

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -2161,15 +2161,18 @@ return window.innerWidth < BREAKPOINTS.screenXsMin ? WINDOW_SIZE_XXS :window.inn
 isWindowBelowBreakpoint:function(size) {
 switch (size) {
 case WINDOW_SIZE_XXS:
-return window.innerWidth < BREAKPOINTS.screenXsMin;
+return !1;
 
 case WINDOW_SIZE_XS:
-return window.innerWidth < BREAKPOINTS.screenSmMin;
+return window.innerWidth < BREAKPOINTS.screenXsMin;
 
 case WINDOW_SIZE_SM:
-return window.innerWidth < BREAKPOINTS.screenMdMin;
+return window.innerWidth < BREAKPOINTS.screenSmMin;
 
 case WINDOW_SIZE_MD:
+return window.innerWidth < BREAKPOINTS.screenMdMin;
+
+case WINDOW_SIZE_LG:
 return window.innerWidth < BREAKPOINTS.screenLgMin;
 
 default:

--- a/src/ui-services/htmlService.js
+++ b/src/ui-services/htmlService.js
@@ -39,15 +39,18 @@ angular.module("openshiftCommonUI")
       isWindowBelowBreakpoint: function(size) {
         switch(size) {
           case WINDOW_SIZE_XXS:
-            return window.innerWidth < BREAKPOINTS.screenXsMin;
+            return false; // Nothing is below xxs
             break;
           case WINDOW_SIZE_XS:
-            return window.innerWidth < BREAKPOINTS.screenSmMin;
+            return window.innerWidth < BREAKPOINTS.screenXsMin;
             break;
           case WINDOW_SIZE_SM:
-            return window.innerWidth < BREAKPOINTS.screenMdMin;
+            return window.innerWidth < BREAKPOINTS.screenSmMin;
             break;
           case WINDOW_SIZE_MD:
+            return window.innerWidth < BREAKPOINTS.screenMdMin;
+            break;
+          case WINDOW_SIZE_LG:
             return window.innerWidth < BREAKPOINTS.screenLgMin;
             break;
           default:


### PR DESCRIPTION
Eating some humble pie here...

Late name change to the isWindowBelowBreakpoint function caused the checks to be out of date with the expectations that come with the new name. 

Sorry I didn't catch this when I updated the name 😿 