### PR TITLE
Use .word-break mixin along with max-width to enable word break within toast notifications.

### DIFF
--- a/dist/less/_notifications.less
+++ b/dist/less/_notifications.less
@@ -8,7 +8,13 @@
 }
 
 .toast-notifications-list-pf {
+  @media(max-width: @screen-xs-max) {
+    // Set max-width when < 769, so that word-break functions on Firefox & IE.
+    // Subtract 40px to align edges with content within container-fluid that has left & right 20px margin
+    max-width: calc(~"100% - 40px");
+  }
   top: 28px;
+  .word-break();
   z-index: @zindex-modal + 5;  // Override Patternfly's z-index to keep toasts above modals but below popovers
 
   > div {

--- a/dist/origin-web-common.css
+++ b/dist/origin-web-common.css
@@ -273,7 +273,16 @@ div.hopscotch-bubble .hopscotch-nav-button.prev {
 }
 .toast-notifications-list-pf {
   top: 28px;
+  word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  min-width: 0;
   z-index: 1055;
+}
+@media (max-width: 767px) {
+  .toast-notifications-list-pf {
+    max-width: calc(100% - 40px);
+  }
 }
 .toast-notifications-list-pf > div.ng-enter {
   animation: toastSlideIn 0.2s ease-out;

--- a/src/styles/_notifications.less
+++ b/src/styles/_notifications.less
@@ -8,7 +8,13 @@
 }
 
 .toast-notifications-list-pf {
+  @media(max-width: @screen-xs-max) {
+    // Set max-width when < 769, so that word-break functions on Firefox & IE.
+    // Subtract 40px to align edges with content within container-fluid that has left & right 20px margin
+    max-width: calc(~"100% - 40px");
+  }
   top: 28px;
+  .word-break();
   z-index: @zindex-modal + 5;  // Override Patternfly's z-index to keep toasts above modals but below popovers
 
   > div {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1770

<img width="411" alt="screen shot 2017-06-27 at 11 46 05 am" src="https://user-images.githubusercontent.com/1874151/27600165-10d6c35a-5b39-11e7-9bd3-bd00694ee69a.png">
<img width="309" alt="screen shot 2017-06-27 at 11 35 28 am" src="https://user-images.githubusercontent.com/1874151/27600166-10d96830-5b39-11e7-83c3-a8f3e2257a17.png">


<img width="619" alt="screen shot 2017-06-27 at 11 33 11 am" src="https://user-images.githubusercontent.com/1874151/27600237-4b7e609e-5b39-11e7-9ade-e45400a0ebc9.png">
