### PR TITLE
Prevent double scrollbars when lots of options within ui-select on bind form

### DIFF
--- a/dist/less/_bind-service.less
+++ b/dist/less/_bind-service.less
@@ -6,6 +6,13 @@
   .application-select {
     margin-top: 10px;
     padding-left: 20px;
+    // Fixes bug https://github.com/openshift/origin-web-console/issues/1814
+    .ui-select-bootstrap > .ui-select-choices {
+      max-height: 100px;
+      @media(min-width: @screen-sm-min) {
+        max-height: 170px;
+      }
+    }
   }
 
   .bind-description {

--- a/dist/origin-web-common.css
+++ b/dist/origin-web-common.css
@@ -25,6 +25,14 @@
   margin-top: 10px;
   padding-left: 20px;
 }
+.bind-form .application-select .ui-select-bootstrap > .ui-select-choices {
+  max-height: 100px;
+}
+@media (min-width: 768px) {
+  .bind-form .application-select .ui-select-bootstrap > .ui-select-choices {
+    max-height: 170px;
+  }
+}
 .bind-form .bind-description {
   padding-left: 20px;
 }

--- a/src/styles/_bind-service.less
+++ b/src/styles/_bind-service.less
@@ -6,6 +6,13 @@
   .application-select {
     margin-top: 10px;
     padding-left: 20px;
+    // Fixes bug https://github.com/openshift/origin-web-console/issues/1814
+    .ui-select-bootstrap > .ui-select-choices {
+      max-height: 100px;
+      @media(min-width: @screen-sm-min) {
+        max-height: 170px;
+      }
+    }
   }
 
   .bind-description {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-console/issues/1814

<img width="958" alt="m1" src="https://user-images.githubusercontent.com/1874151/28139429-3885b81c-6722-11e7-95c4-033ea2383748.png">
<img width="387" alt="m3" src="https://user-images.githubusercontent.com/1874151/28139433-3db87234-6722-11e7-8b82-6707fa512f46.png">

