### PR TITLE
Update jquery (3.2.1), lodash (4.17.4), and patternfly (3.25.1). Bumped Version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-web-common",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "main": [
     "dist/origin-web-common.js",
     "dist/origin-web-common.css"
@@ -33,9 +33,9 @@
     "hawtio-core": "~2.0.37",
     "hawtio-extension-service": "~2.0.2",
     "hopscotch": "~0.2.7",
-    "jquery": "~2.1.4",
-    "lodash": "~3.10.1",
-    "patternfly": "~3.21.0",
+    "jquery": "~3.2.1",
+    "lodash": "~4.17.4",
+    "patternfly": "~3.25.1",
     "uri.js": "~1.18.0"
   },
   "devDependencies": {
@@ -43,6 +43,6 @@
     "angular-scenario": "~1.5.11"
   },
   "resolutions": {
-    "jquery": "~2.1.4"
+    "jquery": "3.2.1"
   }
 }

--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -48,7 +48,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
   var k8sBaseURL = protocol + window.OPENSHIFT_CONFIG.api.k8s.hostPort + window.OPENSHIFT_CONFIG.api.k8s.prefix;
   var k8sDeferred = $.get(k8sBaseURL + "/v1")
     .done(function(data) {
-      api.k8s.v1 = _.indexBy(data.resources, 'name');
+      api.k8s.v1 =  _.keyBy(data.resources, 'name');
     })
     .fail(function(data, textStatus, jqXHR) {
       API_DISCOVERY_ERRORS.push({
@@ -62,7 +62,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
   var osBaseURL = protocol + window.OPENSHIFT_CONFIG.api.openshift.hostPort + window.OPENSHIFT_CONFIG.api.openshift.prefix;
   var osDeferred = $.get(osBaseURL + "/v1")
     .done(function(data) {
-      api.openshift.v1 = _.indexBy(data.resources, 'name');
+      api.openshift.v1 =  _.keyBy(data.resources, 'name');
     })
     .fail(function(data, textStatus, jqXHR) {
       API_DISCOVERY_ERRORS.push({
@@ -110,7 +110,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
         };
         apisDeferredVersions.push($.get(baseURL + "/" + apiVersion.groupVersion)
           .done(function(data) {
-            group.versions[versionStr].resources = _.indexBy(data.resources, 'name');
+            group.versions[versionStr].resources =  _.keyBy(data.resources, 'name');
           })
           .fail(function(data, textStatus, jqXHR) {
             API_DISCOVERY_ERRORS.push({
@@ -476,15 +476,14 @@ angular.module('openshiftCommonServices')
               kind;
     });
 
-
     // ignore the legacy openshift kinds, these have been migrated to api groups
-    _.each(_.pick(API_CFG, function(value, key) {
+    _.each(_.pickBy(API_CFG, function(value, key) {
       return key !== 'openshift';
     }), function(api) {
       _.each(api.resources.v1, function(resource) {
         if (resource.namespaced || includeClusterScoped) {
           // Exclude subresources and any rejected kinds
-          if (_.contains(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
+          if (_.includes(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
             return;
           }
 
@@ -502,7 +501,7 @@ angular.module('openshiftCommonServices')
       var preferredVersion = defaultVersion[group.name] || group.preferredVersion;
       _.each(group.versions[preferredVersion].resources, function(resource) {
         // Exclude subresources and any rejected kinds
-        if (_.contains(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
+        if (_.includes(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
           return;
         }
 
@@ -521,7 +520,7 @@ angular.module('openshiftCommonServices')
       });
     });
 
-    return _.uniq(kinds, false, function(value) {
+    return _.uniqBy(kinds, function(value) {
       return value.group + "/" + value.kind;
     });
   };
@@ -884,7 +883,7 @@ angular.module("openshiftCommonServices")
     //  - subresource that contains '/', eg: 'builds/source', 'builds/logs', ...
     //  - resource is in REVIEW_RESOURCES list
     var checkResource = function(resource) {
-      if (resource === "projectrequests" || _.contains(resource, "/") || _.contains(REVIEW_RESOURCES, resource)) {
+      if (resource === "projectrequests" || _.includes(resource, "/") || _.includes(REVIEW_RESOURCES, resource)) {
         return false;
       } else {
         return true;
@@ -957,7 +956,7 @@ angular.module("openshiftCommonServices")
       if (!verbs) {
         return false;
       }
-      return _.contains(verbs, verb) || _.contains(verbs, '*');
+      return _.includes(verbs, verb) || _.includes(verbs, '*');
     };
 
     // canI checks whether any rule allows the specified verb on the specified group-resource (directly or via a wildcard rule).
@@ -1050,7 +1049,7 @@ angular.module("openshiftCommonServices")
     var generateName = $filter('generateName');
     var makeBinding = function (serviceInstance, application, parameters) {
       var instanceName = serviceInstance.metadata.name;
-      var relatedObjName = generateName(_.trunc(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + '-');
+      var relatedObjName = generateName(_.truncate(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + '-');
       var binding = {
         kind: 'Binding',
         apiVersion: 'servicecatalog.k8s.io/v1alpha1',

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -48,7 +48,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
   var k8sBaseURL = protocol + window.OPENSHIFT_CONFIG.api.k8s.hostPort + window.OPENSHIFT_CONFIG.api.k8s.prefix;
   var k8sDeferred = $.get(k8sBaseURL + "/v1")
     .done(function(data) {
-      api.k8s.v1 = _.indexBy(data.resources, 'name');
+      api.k8s.v1 =  _.keyBy(data.resources, 'name');
     })
     .fail(function(data, textStatus, jqXHR) {
       API_DISCOVERY_ERRORS.push({
@@ -62,7 +62,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
   var osBaseURL = protocol + window.OPENSHIFT_CONFIG.api.openshift.hostPort + window.OPENSHIFT_CONFIG.api.openshift.prefix;
   var osDeferred = $.get(osBaseURL + "/v1")
     .done(function(data) {
-      api.openshift.v1 = _.indexBy(data.resources, 'name');
+      api.openshift.v1 =  _.keyBy(data.resources, 'name');
     })
     .fail(function(data, textStatus, jqXHR) {
       API_DISCOVERY_ERRORS.push({
@@ -110,7 +110,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
         };
         apisDeferredVersions.push($.get(baseURL + "/" + apiVersion.groupVersion)
           .done(function(data) {
-            group.versions[versionStr].resources = _.indexBy(data.resources, 'name');
+            group.versions[versionStr].resources =  _.keyBy(data.resources, 'name');
           })
           .fail(function(data, textStatus, jqXHR) {
             API_DISCOVERY_ERRORS.push({
@@ -2242,15 +2242,14 @@ angular.module('openshiftCommonServices')
               kind;
     });
 
-
     // ignore the legacy openshift kinds, these have been migrated to api groups
-    _.each(_.pick(API_CFG, function(value, key) {
+    _.each(_.pickBy(API_CFG, function(value, key) {
       return key !== 'openshift';
     }), function(api) {
       _.each(api.resources.v1, function(resource) {
         if (resource.namespaced || includeClusterScoped) {
           // Exclude subresources and any rejected kinds
-          if (_.contains(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
+          if (_.includes(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
             return;
           }
 
@@ -2268,7 +2267,7 @@ angular.module('openshiftCommonServices')
       var preferredVersion = defaultVersion[group.name] || group.preferredVersion;
       _.each(group.versions[preferredVersion].resources, function(resource) {
         // Exclude subresources and any rejected kinds
-        if (_.contains(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
+        if (_.includes(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
           return;
         }
 
@@ -2287,7 +2286,7 @@ angular.module('openshiftCommonServices')
       });
     });
 
-    return _.uniq(kinds, false, function(value) {
+    return _.uniqBy(kinds, function(value) {
       return value.group + "/" + value.kind;
     });
   };
@@ -2650,7 +2649,7 @@ angular.module("openshiftCommonServices")
     //  - subresource that contains '/', eg: 'builds/source', 'builds/logs', ...
     //  - resource is in REVIEW_RESOURCES list
     var checkResource = function(resource) {
-      if (resource === "projectrequests" || _.contains(resource, "/") || _.contains(REVIEW_RESOURCES, resource)) {
+      if (resource === "projectrequests" || _.includes(resource, "/") || _.includes(REVIEW_RESOURCES, resource)) {
         return false;
       } else {
         return true;
@@ -2723,7 +2722,7 @@ angular.module("openshiftCommonServices")
       if (!verbs) {
         return false;
       }
-      return _.contains(verbs, verb) || _.contains(verbs, '*');
+      return _.includes(verbs, verb) || _.includes(verbs, '*');
     };
 
     // canI checks whether any rule allows the specified verb on the specified group-resource (directly or via a wildcard rule).
@@ -2816,7 +2815,7 @@ angular.module("openshiftCommonServices")
     var generateName = $filter('generateName');
     var makeBinding = function (serviceInstance, application, parameters) {
       var instanceName = serviceInstance.metadata.name;
-      var relatedObjName = generateName(_.trunc(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + '-');
+      var relatedObjName = generateName(_.truncate(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + '-');
       var binding = {
         kind: 'Binding',
         apiVersion: 'servicecatalog.k8s.io/v1alpha1',

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -12,7 +12,7 @@ var api = {
 k8s:{},
 openshift:{}
 }, apis = {}, API_DISCOVERY_ERRORS = [], protocol = window.location.protocol + "//", k8sBaseURL = protocol + window.OPENSHIFT_CONFIG.api.k8s.hostPort + window.OPENSHIFT_CONFIG.api.k8s.prefix, k8sDeferred = $.get(k8sBaseURL + "/v1").done(function(data) {
-api.k8s.v1 = _.indexBy(data.resources, "name");
+api.k8s.v1 = _.keyBy(data.resources, "name");
 }).fail(function(data, textStatus, jqXHR) {
 API_DISCOVERY_ERRORS.push({
 data:data,
@@ -20,7 +20,7 @@ textStatus:textStatus,
 xhr:jqXHR
 });
 }), osBaseURL = protocol + window.OPENSHIFT_CONFIG.api.openshift.hostPort + window.OPENSHIFT_CONFIG.api.openshift.prefix, osDeferred = $.get(osBaseURL + "/v1").done(function(data) {
-api.openshift.v1 = _.indexBy(data.resources, "name");
+api.openshift.v1 = _.keyBy(data.resources, "name");
 }).fail(function(data, textStatus, jqXHR) {
 API_DISCOVERY_ERRORS.push({
 data:data,
@@ -42,7 +42,7 @@ group.versions[versionStr] = {
 version:versionStr,
 groupVersion:apiVersion.groupVersion
 }, apisDeferredVersions.push($.get(baseURL + "/" + apiVersion.groupVersion).done(function(data) {
-group.versions[versionStr].resources = _.indexBy(data.resources, "name");
+group.versions[versionStr].resources = _.keyBy(data.resources, "name");
 }).fail(function(data, textStatus, jqXHR) {
 API_DISCOVERY_ERRORS.push({
 data:data,
@@ -882,12 +882,12 @@ kind:kind,
 group:""
 } :kind;
 });
-return _.each(_.pick(API_CFG, function(value, key) {
+return _.each(_.pickBy(API_CFG, function(value, key) {
 return "openshift" !== key;
 }), function(api) {
 _.each(api.resources.v1, function(resource) {
 if (resource.namespaced || includeClusterScoped) {
-if (_.contains(resource.name, "/") || _.find(rejectedKinds, {
+if (_.includes(resource.name, "/") || _.find(rejectedKinds, {
 kind:resource.kind,
 group:""
 })) return;
@@ -900,7 +900,7 @@ group:""
 }), _.each(APIS_CFG.groups, function(group) {
 var preferredVersion = defaultVersion[group.name] || group.preferredVersion;
 _.each(group.versions[preferredVersion].resources, function(resource) {
-_.contains(resource.name, "/") || _.find(rejectedKinds, {
+_.includes(resource.name, "/") || _.find(rejectedKinds, {
 kind:resource.kind,
 group:group.name
 }) || ("extensions" !== group.name || "HorizontalPodAutoscaler" !== resource.kind) && (resource.namespaced || includeClusterScoped) && kinds.push({
@@ -908,7 +908,7 @@ kind:resource.kind,
 group:group.name
 });
 });
-}), _.uniq(kinds, !1, function(value) {
+}), _.uniqBy(kinds, function(value) {
 return value.group + "/" + value.kind;
 });
 }, namespacedKinds = calculateAvailableKinds(!1), allKinds = calculateAvailableKinds(!0), availableKinds = function(includeClusterScoped) {
@@ -1048,7 +1048,7 @@ normalizedRules[apiGroup][resource] = rule.verbs;
 });
 }), normalizedRules;
 }, checkResource = function(resource) {
-return "projectrequests" === resource || _.contains(resource, "/") || _.contains(REVIEW_RESOURCES, resource) ? !1 :!0;
+return "projectrequests" === resource || _.includes(resource, "/") || _.includes(REVIEW_RESOURCES, resource) ? !1 :!0;
 }, canAddToProjectCheck = function(rules) {
 return _.some(rules, function(rule) {
 return _.some(rule.resources, function(resource) {
@@ -1086,7 +1086,7 @@ return _.get(cachedRulesByProject.get(projectName || currentProject), [ "rules" 
 var resources = rules[group];
 if (!resources) return !1;
 var verbs = resources[resource];
-return verbs ? _.contains(verbs, verb) || _.contains(verbs, "*") :!1;
+return verbs ? _.includes(verbs, verb) || _.includes(verbs, "*") :!1;
 }, canI = function(resource, verb, projectName) {
 if (permissiveMode) return !0;
 var r = APIService.toResourceGroupVersion(resource), rules = getRulesForProject(projectName || currentProject);
@@ -1140,7 +1140,7 @@ return {
 };
 }) :$q.when({});
 }, generateName = $filter("generateName"), makeBinding = function(serviceInstance, application, parameters) {
-var instanceName = serviceInstance.metadata.name, relatedObjName = generateName(_.trunc(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + "-"), binding = {
+var instanceName = serviceInstance.metadata.name, relatedObjName = generateName(_.truncate(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + "-"), binding = {
 kind:"Binding",
 apiVersion:"servicecatalog.k8s.io/v1alpha1",
 metadata:{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Red Hat",
   "name": "origin-web-common",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "license": "Apache-2.0",
   "description": "Library of common services and components for OpenShift Web Console.",
   "homepage": "https://github.com/openshift/origin-web-common.git",

--- a/src/openshiftCommonServices.module.js
+++ b/src/openshiftCommonServices.module.js
@@ -48,7 +48,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
   var k8sBaseURL = protocol + window.OPENSHIFT_CONFIG.api.k8s.hostPort + window.OPENSHIFT_CONFIG.api.k8s.prefix;
   var k8sDeferred = $.get(k8sBaseURL + "/v1")
     .done(function(data) {
-      api.k8s.v1 = _.indexBy(data.resources, 'name');
+      api.k8s.v1 =  _.keyBy(data.resources, 'name');
     })
     .fail(function(data, textStatus, jqXHR) {
       API_DISCOVERY_ERRORS.push({
@@ -62,7 +62,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
   var osBaseURL = protocol + window.OPENSHIFT_CONFIG.api.openshift.hostPort + window.OPENSHIFT_CONFIG.api.openshift.prefix;
   var osDeferred = $.get(osBaseURL + "/v1")
     .done(function(data) {
-      api.openshift.v1 = _.indexBy(data.resources, 'name');
+      api.openshift.v1 =  _.keyBy(data.resources, 'name');
     })
     .fail(function(data, textStatus, jqXHR) {
       API_DISCOVERY_ERRORS.push({
@@ -110,7 +110,7 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
         };
         apisDeferredVersions.push($.get(baseURL + "/" + apiVersion.groupVersion)
           .done(function(data) {
-            group.versions[versionStr].resources = _.indexBy(data.resources, 'name');
+            group.versions[versionStr].resources =  _.keyBy(data.resources, 'name');
           })
           .fail(function(data, textStatus, jqXHR) {
             API_DISCOVERY_ERRORS.push({

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -283,15 +283,14 @@ angular.module('openshiftCommonServices')
               kind;
     });
 
-
     // ignore the legacy openshift kinds, these have been migrated to api groups
-    _.each(_.pick(API_CFG, function(value, key) {
+    _.each(_.pickBy(API_CFG, function(value, key) {
       return key !== 'openshift';
     }), function(api) {
       _.each(api.resources.v1, function(resource) {
         if (resource.namespaced || includeClusterScoped) {
           // Exclude subresources and any rejected kinds
-          if (_.contains(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
+          if (_.includes(resource.name, '/') || _.find(rejectedKinds, { kind: resource.kind, group: '' })) {
             return;
           }
 
@@ -309,7 +308,7 @@ angular.module('openshiftCommonServices')
       var preferredVersion = defaultVersion[group.name] || group.preferredVersion;
       _.each(group.versions[preferredVersion].resources, function(resource) {
         // Exclude subresources and any rejected kinds
-        if (_.contains(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
+        if (_.includes(resource.name, '/') || _.find(rejectedKinds, {kind: resource.kind, group: group.name})) {
           return;
         }
 
@@ -328,7 +327,7 @@ angular.module('openshiftCommonServices')
       });
     });
 
-    return _.uniq(kinds, false, function(value) {
+    return _.uniqBy(kinds, function(value) {
       return value.group + "/" + value.kind;
     });
   };

--- a/src/services/authorizationService.js
+++ b/src/services/authorizationService.js
@@ -36,7 +36,7 @@ angular.module("openshiftCommonServices")
     //  - subresource that contains '/', eg: 'builds/source', 'builds/logs', ...
     //  - resource is in REVIEW_RESOURCES list
     var checkResource = function(resource) {
-      if (resource === "projectrequests" || _.contains(resource, "/") || _.contains(REVIEW_RESOURCES, resource)) {
+      if (resource === "projectrequests" || _.includes(resource, "/") || _.includes(REVIEW_RESOURCES, resource)) {
         return false;
       } else {
         return true;
@@ -109,7 +109,7 @@ angular.module("openshiftCommonServices")
       if (!verbs) {
         return false;
       }
-      return _.contains(verbs, verb) || _.contains(verbs, '*');
+      return _.includes(verbs, verb) || _.includes(verbs, '*');
     };
 
     // canI checks whether any rule allows the specified verb on the specified group-resource (directly or via a wildcard rule).

--- a/src/services/bindService.js
+++ b/src/services/bindService.js
@@ -38,7 +38,7 @@ angular.module("openshiftCommonServices")
     var generateName = $filter('generateName');
     var makeBinding = function (serviceInstance, application, parameters) {
       var instanceName = serviceInstance.metadata.name;
-      var relatedObjName = generateName(_.trunc(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + '-');
+      var relatedObjName = generateName(_.truncate(instanceName, DNS1123_SUBDOMAIN_VALIDATION.maxlength - 6) + '-');
       var binding = {
         kind: 'Binding',
         apiVersion: 'servicecatalog.k8s.io/v1alpha1',


### PR DESCRIPTION
This PR updates the following dependencies:

Dependency | Version & Changes
-- | -- |
patternfly | 3.25.1
jQuery | ~2.1.4 => 3.2.1
lodash | ~3.10.1 => 4.17.4 <br>_The following changes were made:_ <br>_.indexBy => _.keyBy <br>_.pick(object,func) ⇒  _.pickBy(object,func) <br> _.contains => _.includes <br> _.trunc => _.truncate <br> _.uniq => _.uniqBy

These match the dependencies used in patternfly and angular-patternfly. 