### PR TITLE
Add opts.skipDigest for DataService.watch

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -1736,6 +1736,9 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
 //            pollInterval: in milliseconds, how long to wait between polling the server
 //                    only applies if poll=true.  Default is 5000.
 //            http:   similar to .get, etc. at this point, only used to pass http.params for filtering
+//            skipDigest: will skip the $apply & avoid triggering a digest loop
+//                    if set to `true`.  Is intentionally the inverse of the invokeApply
+//                    arg passed to $timeout (due to default values).
 //            errorNotification: will popup an error notification if the API request fails (default true)
 // returns handle to the watch, needed to unwatch e.g.
 //        var handle = DataService.watch(resource,context,callback[,opts])
@@ -1743,6 +1746,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
   DataService.prototype.watch = function(resource, context, callback, opts) {
     resource = APIService.toResourceGroupVersion(resource);
     opts = opts || {};
+    var invokeApply =  !opts.skipDigest;
     var key = this._uniqueKey(resource, null, context, _.get(opts, 'http.params'));
     if (callback) {
       // If we were given a callback, add it
@@ -1770,7 +1774,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       if (callback) {
         $timeout(function() {
           callback(self._data(key));
-        }, 0);
+        }, 0, invokeApply);
       }
     }
     else {
@@ -1782,7 +1786,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
             if (resourceVersion === self._resourceVersion(key)) {
               callback(self._data(key)); // but just in case, still pull from the current data map
             }
-          }, 0);
+          }, 0, invokeApply);
         }
       }
       if (!this._listInFlight(key)) {
@@ -2245,6 +2249,8 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
 
   DataService.prototype._watchOpOnMessage = function(resource, context, opts, event) {
     var key = this._uniqueKey(resource, null, context, _.get(opts, 'http.params'));
+    opts = opts || {};
+    var invokeApply = !opts.skipDigest;
     try {
       var eventData = $.parseJSON(event.data);
 
@@ -2274,7 +2280,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       // without timeout this is triggering a repeated digest loop
       $timeout(function() {
         self._watchCallbacks(key).fire(self._data(key), eventData.type, eventData.object);
-      }, 0);
+      }, 0, invokeApply);
     }
     catch (e) {
       // TODO: surface in the UI?

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1471,7 +1471,7 @@ ws.close();
 };
 }, DataService.prototype.watch = function(resource, context, callback, opts) {
 resource = APIService.toResourceGroupVersion(resource), opts = opts || {};
-var key = this._uniqueKey(resource, null, context, _.get(opts, "http.params"));
+var invokeApply = !opts.skipDigest, key = this._uniqueKey(resource, null, context, _.get(opts, "http.params"));
 if (callback) this._watchCallbacks(key).add(callback); else if (!this._watchCallbacks(key).has()) return {};
 var existingWatchOpts = this._watchOptions(key);
 if (existingWatchOpts) {
@@ -1480,12 +1480,12 @@ if (!!existingWatchOpts.poll != !!opts.poll) throw "A watch already exists for "
 var self = this;
 if (this._isCached(key)) callback && $timeout(function() {
 callback(self._data(key));
-}, 0); else {
+}, 0, invokeApply); else {
 if (callback) {
 var resourceVersion = this._resourceVersion(key);
 this._data(key) && $timeout(function() {
 resourceVersion === self._resourceVersion(key) && callback(self._data(key));
-}, 0);
+}, 0, invokeApply);
 }
 this._listInFlight(key) || this._startListOp(resource, context, opts);
 }
@@ -1645,6 +1645,8 @@ var key = this._uniqueKey(resource, null, context, _.get(opts, "http.params"));
 this._addWebsocketEvent(key, "open");
 }, DataService.prototype._watchOpOnMessage = function(resource, context, opts, event) {
 var key = this._uniqueKey(resource, null, context, _.get(opts, "http.params"));
+opts = opts || {};
+var invokeApply = !opts.skipDigest;
 try {
 var eventData = $.parseJSON(event.data);
 if ("ERROR" == eventData.type) return Logger.log("Watch window expired for resource/context", resource, context), void (event.target && (event.target.shouldRelist = !0));
@@ -1652,7 +1654,7 @@ if ("ERROR" == eventData.type) return Logger.log("Watch window expired for resou
 var self = this;
 $timeout(function() {
 self._watchCallbacks(key).fire(self._data(key), eventData.type, eventData.object);
-}, 0);
+}, 0, invokeApply);
 } catch (e) {
 Logger.error("Error processing message", resource, event.data);
 }

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -602,6 +602,9 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
 //            pollInterval: in milliseconds, how long to wait between polling the server
 //                    only applies if poll=true.  Default is 5000.
 //            http:   similar to .get, etc. at this point, only used to pass http.params for filtering
+//            skipDigest: will skip the $apply & avoid triggering a digest loop
+//                    if set to `true`.  Is intentionally the inverse of the invokeApply
+//                    arg passed to $timeout (due to default values).
 //            errorNotification: will popup an error notification if the API request fails (default true)
 // returns handle to the watch, needed to unwatch e.g.
 //        var handle = DataService.watch(resource,context,callback[,opts])
@@ -609,6 +612,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
   DataService.prototype.watch = function(resource, context, callback, opts) {
     resource = APIService.toResourceGroupVersion(resource);
     opts = opts || {};
+    var invokeApply =  !opts.skipDigest;
     var key = this._uniqueKey(resource, null, context, _.get(opts, 'http.params'));
     if (callback) {
       // If we were given a callback, add it
@@ -636,7 +640,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       if (callback) {
         $timeout(function() {
           callback(self._data(key));
-        }, 0);
+        }, 0, invokeApply);
       }
     }
     else {
@@ -648,7 +652,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
             if (resourceVersion === self._resourceVersion(key)) {
               callback(self._data(key)); // but just in case, still pull from the current data map
             }
-          }, 0);
+          }, 0, invokeApply);
         }
       }
       if (!this._listInFlight(key)) {
@@ -1111,6 +1115,8 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
 
   DataService.prototype._watchOpOnMessage = function(resource, context, opts, event) {
     var key = this._uniqueKey(resource, null, context, _.get(opts, 'http.params'));
+    opts = opts || {};
+    var invokeApply = !opts.skipDigest;
     try {
       var eventData = $.parseJSON(event.data);
 
@@ -1140,7 +1146,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       // without timeout this is triggering a repeated digest loop
       $timeout(function() {
         self._watchCallbacks(key).fire(self._data(key), eventData.type, eventData.object);
-      }, 0);
+      }, 0, invokeApply);
     }
     catch (e) {
       // TODO: surface in the UI?


### PR DESCRIPTION
- provides mechanism to keep WebSockets from spamming the `$digest` loop
- flips `invokeApply` passed to the internal `$timeout` calls,
  stopping a `$digest` loop & avoiding a render.
- `DataService._watchOpOnMessage` also honors the `suppressDigest` flag,
  which is plumbed down through `.watch` -> `.startListOp` -> `._listOpComplete` -> `._startWatchOp` -> `._watchOpOnMessage`

example usage:

```javascript 
DataService.watch(resource, context, (data) => {
  // optionally call $applyAsync here in controlling code
  // to manually run a $digest
  $scope.$applyAsync(() => {
   // do stuff with data here
  });
}, { suppressDigest: true });

// or debounced 
DataService.watch(resource, context, _.debounce((data) => {
  // $apply here, inside debounce
}, 400), { suppressDigest: true });
```

@spadgett @jwforres for review 