### PR TITLE
Recently Viewed Projects Service

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -561,7 +561,7 @@ angular.module("openshiftCommonUI")
         isDialog: '@'
       },
       templateUrl: 'src/components/create-project/createProject.html',
-      controller: function($scope, $filter, $location, DataService, NotificationsService, displayNameFilter) {
+      controller: function($scope, $location, ProjectsService, NotificationsService, displayNameFilter) {
         if(!($scope.submitButtonLabel)) {
           $scope.submitButtonLabel = 'Create';
         }
@@ -575,27 +575,18 @@ angular.module("openshiftCommonUI")
         $scope.createProject = function() {
           $scope.disableInputs = true;
           if ($scope.createProjectForm.$valid) {
-            DataService
-              .create('projectrequests', null, {
-                apiVersion: "v1",
-                kind: "ProjectRequest",
-                metadata: {
-                  name: $scope.name
-                },
-                displayName: $scope.displayName,
-                description: $scope.description
-              }, $scope)
-              .then(function(data) {
+            ProjectsService.create($scope.name, $scope.displayName, $scope.description)
+              .then(function(project) {
                 // angular is actually wrapping the redirect action
                 var cb = $scope.redirectAction();
                 if (cb) {
-                  cb(encodeURIComponent(data.metadata.name));
+                  cb(encodeURIComponent(project.metadata.name));
                 } else {
-                  $location.path("project/" + encodeURIComponent(data.metadata.name) + "/create");
+                  $location.path("project/" + encodeURIComponent(project.metadata.name) + "/create");
                 }
                 NotificationsService.addNotification({
                   type: "success",
-                  message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
+                  message: "Project \'"  + displayNameFilter(project) + "\' was successfully created."
                 });
               }, function(result) {
                 $scope.disableInputs = false;
@@ -626,7 +617,7 @@ angular.module("openshiftCommonUI")
         };
 
         $scope.$on("$destroy", hideErrorNotifications);
-      },
+      }
     };
   });
 ;'use strict';

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -732,7 +732,7 @@ angular.module("openshiftCommonUI")
         isDialog: '@'
       },
       templateUrl: 'src/components/create-project/createProject.html',
-      controller: ["$scope", "$filter", "$location", "DataService", "NotificationsService", "displayNameFilter", function($scope, $filter, $location, DataService, NotificationsService, displayNameFilter) {
+      controller: ["$scope", "$location", "ProjectsService", "NotificationsService", "displayNameFilter", function($scope, $location, ProjectsService, NotificationsService, displayNameFilter) {
         if(!($scope.submitButtonLabel)) {
           $scope.submitButtonLabel = 'Create';
         }
@@ -746,27 +746,18 @@ angular.module("openshiftCommonUI")
         $scope.createProject = function() {
           $scope.disableInputs = true;
           if ($scope.createProjectForm.$valid) {
-            DataService
-              .create('projectrequests', null, {
-                apiVersion: "v1",
-                kind: "ProjectRequest",
-                metadata: {
-                  name: $scope.name
-                },
-                displayName: $scope.displayName,
-                description: $scope.description
-              }, $scope)
-              .then(function(data) {
+            ProjectsService.create($scope.name, $scope.displayName, $scope.description)
+              .then(function(project) {
                 // angular is actually wrapping the redirect action
                 var cb = $scope.redirectAction();
                 if (cb) {
-                  cb(encodeURIComponent(data.metadata.name));
+                  cb(encodeURIComponent(project.metadata.name));
                 } else {
-                  $location.path("project/" + encodeURIComponent(data.metadata.name) + "/create");
+                  $location.path("project/" + encodeURIComponent(project.metadata.name) + "/create");
                 }
                 NotificationsService.addNotification({
                   type: "success",
-                  message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
+                  message: "Project \'"  + displayNameFilter(project) + "\' was successfully created."
                 });
               }, function(result) {
                 $scope.disableInputs = false;
@@ -797,7 +788,7 @@ angular.module("openshiftCommonUI")
         };
 
         $scope.$on("$destroy", hideErrorNotifications);
-      }],
+      }]
     };
   }]);
 ;'use strict';
@@ -4782,7 +4773,7 @@ angular.module('openshiftCommonServices')
 
 angular.module('openshiftCommonServices')
   .factory('ProjectsService',
-    ["$location", "$q", "AuthService", "DataService", "annotationNameFilter", "AuthorizationService", function($location, $q, AuthService, DataService, annotationNameFilter, AuthorizationService) {
+    ["$location", "$q", "AuthService", "DataService", "annotationNameFilter", "AuthorizationService", "RecentlyViewedProjectsService", function($location, $q, AuthService, DataService, annotationNameFilter, AuthorizationService, RecentlyViewedProjectsService) {
 
 
       var cleanEditableAnnotations = function(resource) {
@@ -4817,6 +4808,7 @@ angular.module('openshiftCommonServices')
                                         .then(function() {
                                           context.project = project;
                                           context.projectPromise.resolve(project);
+                                          RecentlyViewedProjectsService.addProjectUID(project.metadata.uid);
                                           // TODO: fix need to return context & projectPromise
                                           return [project, context];
                                         });
@@ -4847,11 +4839,91 @@ angular.module('openshiftCommonServices')
             return DataService
                     .update('projects', projectName, cleanEditableAnnotations(data), {projectName: projectName}, {errorNotification: false});
           },
+          create: function(name, displayName, description) {
+            var projectRequest = {
+              apiVersion: "v1",
+              kind: "ProjectRequest",
+              metadata: {
+                name: name
+              },
+              displayName: displayName,
+              description: description
+            };
+            return DataService
+              .create('projectrequests', null, projectRequest, {})
+              .then(function(project) {
+                RecentlyViewedProjectsService.addProjectUID(project.metadata.uid);
+                return project;
+              });
+          },
           canCreate: function() {
             return DataService.get("projectrequests", null, {}, { errorNotification: false});
           }
         };
     }]);
+;'use strict';
+
+angular.module("openshiftCommonServices")
+  .service("RecentlyViewedProjectsService", ["$filter", function($filter){
+
+    var recentlyViewedProjsKey = "openshift/recently-viewed-project-uids";
+
+    var getProjectUIDs = function() {
+      var recentlyViewed = localStorage.getItem(recentlyViewedProjsKey);
+      return recentlyViewed ? JSON.parse(recentlyViewed) : [];
+    };
+
+    var addProjectUID = function(uid) {
+      var recentlyViewed = getProjectUIDs();
+
+      // add to front of list
+      recentlyViewed.unshift(uid);
+
+      // no dups
+      recentlyViewed = _.uniq(recentlyViewed);
+
+      // limit to 5 items
+      recentlyViewed = _.take(recentlyViewed, 5);
+
+      setRecentlyViewedProjects(recentlyViewed);
+    };
+
+    var clear = function() {
+      localStorage.removeItem(recentlyViewedProjsKey);
+    };
+
+    var setRecentlyViewedProjects = function(recentlyViewed) {
+      localStorage.setItem(recentlyViewedProjsKey, JSON.stringify(recentlyViewed));
+    };
+
+    var orderByMostRecentlyViewed = function(projects) {
+      var recentlyViewedProjects = [];
+      var recentlyViewedIds = getProjectUIDs();
+
+      // remove mostRecentlyViewed projects
+      _.each(recentlyViewedIds, function(uid) {
+        var proj = _.remove(projects, function(project) {
+          return project.metadata.uid === uid;
+        })[0];
+        if(proj !== undefined) {
+          recentlyViewedProjects.push(proj);
+        }
+      });
+
+      // order by creationDate
+      projects =  $filter('orderObjectsByDate')(projects, true);
+
+      // return array where moveRecentlyViewed is first, then sorted by creationDate
+      return recentlyViewedProjects.concat(projects);
+    };
+
+    return {
+      getProjectUIDs: getProjectUIDs,
+      addProjectUID: addProjectUID,
+      orderByMostRecentlyViewed: orderByMostRecentlyViewed,
+      clear: clear
+    };
+  }]);
 ;'use strict';
 
 // Login strategies

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -163,25 +163,17 @@ onCancel:"&?",
 isDialog:"@"
 },
 templateUrl:"src/components/create-project/createProject.html",
-controller:[ "$scope", "$filter", "$location", "DataService", "NotificationsService", "displayNameFilter", function($scope, $filter, $location, DataService, NotificationsService, displayNameFilter) {
+controller:[ "$scope", "$location", "ProjectsService", "NotificationsService", "displayNameFilter", function($scope, $location, ProjectsService, NotificationsService, displayNameFilter) {
 $scope.submitButtonLabel || ($scope.submitButtonLabel = "Create"), $scope.isDialog = "true" === $scope.isDialog;
 var hideErrorNotifications = function() {
 NotificationsService.hideNotification("create-project-error");
 };
 $scope.createProject = function() {
-$scope.disableInputs = !0, $scope.createProjectForm.$valid && DataService.create("projectrequests", null, {
-apiVersion:"v1",
-kind:"ProjectRequest",
-metadata:{
-name:$scope.name
-},
-displayName:$scope.displayName,
-description:$scope.description
-}, $scope).then(function(data) {
+$scope.disableInputs = !0, $scope.createProjectForm.$valid && ProjectsService.create($scope.name, $scope.displayName, $scope.description).then(function(project) {
 var cb = $scope.redirectAction();
-cb ? cb(encodeURIComponent(data.metadata.name)) :$location.path("project/" + encodeURIComponent(data.metadata.name) + "/create"), NotificationsService.addNotification({
+cb ? cb(encodeURIComponent(project.metadata.name)) :$location.path("project/" + encodeURIComponent(project.metadata.name) + "/create"), NotificationsService.addNotification({
 type:"success",
-message:"Project '" + displayNameFilter(data) + "' was successfully created."
+message:"Project '" + displayNameFilter(project) + "' was successfully created."
 });
 }, function(result) {
 $scope.disableInputs = !1;
@@ -1997,7 +1989,7 @@ token ? (authLogger.log("LocalStorageUserStore.setToken", token, ttl), localStor
 }
 };
 } ];
-}), angular.module("openshiftCommonServices").factory("ProjectsService", [ "$location", "$q", "AuthService", "DataService", "annotationNameFilter", "AuthorizationService", function($location, $q, AuthService, DataService, annotationNameFilter, AuthorizationService) {
+}), angular.module("openshiftCommonServices").factory("ProjectsService", [ "$location", "$q", "AuthService", "DataService", "annotationNameFilter", "AuthorizationService", "RecentlyViewedProjectsService", function($location, $q, AuthService, DataService, annotationNameFilter, AuthorizationService, RecentlyViewedProjectsService) {
 var cleanEditableAnnotations = function(resource) {
 var paths = [ annotationNameFilter("description"), annotationNameFilter("displayName") ];
 return _.each(paths, function(path) {
@@ -2016,7 +2008,7 @@ return DataService.get("projects", projectName, context, {
 errorNotification:!1
 }).then(function(project) {
 return AuthorizationService.getProjectRules(projectName).then(function() {
-return context.project = project, context.projectPromise.resolve(project), [ project, context ];
+return context.project = project, context.projectPromise.resolve(project), RecentlyViewedProjectsService.addProjectUID(project.metadata.uid), [ project, context ];
 });
 }, function(e) {
 context.projectPromise.reject(e);
@@ -2035,11 +2027,51 @@ projectName:projectName
 errorNotification:!1
 });
 },
+create:function(name, displayName, description) {
+var projectRequest = {
+apiVersion:"v1",
+kind:"ProjectRequest",
+metadata:{
+name:name
+},
+displayName:displayName,
+description:description
+};
+return DataService.create("projectrequests", null, projectRequest, {}).then(function(project) {
+return RecentlyViewedProjectsService.addProjectUID(project.metadata.uid), project;
+});
+},
 canCreate:function() {
 return DataService.get("projectrequests", null, {}, {
 errorNotification:!1
 });
 }
+};
+} ]), angular.module("openshiftCommonServices").service("RecentlyViewedProjectsService", [ "$filter", function($filter) {
+var recentlyViewedProjsKey = "openshift/recently-viewed-project-uids", getProjectUIDs = function() {
+var recentlyViewed = localStorage.getItem(recentlyViewedProjsKey);
+return recentlyViewed ? JSON.parse(recentlyViewed) :[];
+}, addProjectUID = function(uid) {
+var recentlyViewed = getProjectUIDs();
+recentlyViewed.unshift(uid), recentlyViewed = _.uniq(recentlyViewed), recentlyViewed = _.take(recentlyViewed, 5), setRecentlyViewedProjects(recentlyViewed);
+}, clear = function() {
+localStorage.removeItem(recentlyViewedProjsKey);
+}, setRecentlyViewedProjects = function(recentlyViewed) {
+localStorage.setItem(recentlyViewedProjsKey, JSON.stringify(recentlyViewed));
+}, orderByMostRecentlyViewed = function(projects) {
+var recentlyViewedProjects = [], recentlyViewedIds = getProjectUIDs();
+return _.each(recentlyViewedIds, function(uid) {
+var proj = _.remove(projects, function(project) {
+return project.metadata.uid === uid;
+})[0];
+void 0 !== proj && recentlyViewedProjects.push(proj);
+}), projects = $filter("orderObjectsByDate")(projects, !0), recentlyViewedProjects.concat(projects);
+};
+return {
+getProjectUIDs:getProjectUIDs,
+addProjectUID:addProjectUID,
+orderByMostRecentlyViewed:orderByMostRecentlyViewed,
+clear:clear
 };
 } ]), angular.module("openshiftCommonServices").provider("RedirectLoginService", function() {
 var _oauth_client_id = "", _oauth_authorize_uri = "", _oauth_token_uri = "", _oauth_redirect_uri = "";

--- a/src/components/create-project/createProject.js
+++ b/src/components/create-project/createProject.js
@@ -11,7 +11,7 @@ angular.module("openshiftCommonUI")
         isDialog: '@'
       },
       templateUrl: 'src/components/create-project/createProject.html',
-      controller: function($scope, $filter, $location, DataService, NotificationsService, displayNameFilter) {
+      controller: function($scope, $location, ProjectsService, NotificationsService, displayNameFilter) {
         if(!($scope.submitButtonLabel)) {
           $scope.submitButtonLabel = 'Create';
         }
@@ -25,27 +25,18 @@ angular.module("openshiftCommonUI")
         $scope.createProject = function() {
           $scope.disableInputs = true;
           if ($scope.createProjectForm.$valid) {
-            DataService
-              .create('projectrequests', null, {
-                apiVersion: "v1",
-                kind: "ProjectRequest",
-                metadata: {
-                  name: $scope.name
-                },
-                displayName: $scope.displayName,
-                description: $scope.description
-              }, $scope)
-              .then(function(data) {
+            ProjectsService.create($scope.name, $scope.displayName, $scope.description)
+              .then(function(project) {
                 // angular is actually wrapping the redirect action
                 var cb = $scope.redirectAction();
                 if (cb) {
-                  cb(encodeURIComponent(data.metadata.name));
+                  cb(encodeURIComponent(project.metadata.name));
                 } else {
-                  $location.path("project/" + encodeURIComponent(data.metadata.name) + "/create");
+                  $location.path("project/" + encodeURIComponent(project.metadata.name) + "/create");
                 }
                 NotificationsService.addNotification({
                   type: "success",
-                  message: "Project \'"  + displayNameFilter(data) + "\' was successfully created."
+                  message: "Project \'"  + displayNameFilter(project) + "\' was successfully created."
                 });
               }, function(result) {
                 $scope.disableInputs = false;
@@ -76,6 +67,6 @@ angular.module("openshiftCommonUI")
         };
 
         $scope.$on("$destroy", hideErrorNotifications);
-      },
+      }
     };
   });

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -2,7 +2,7 @@
 
 angular.module('openshiftCommonServices')
   .factory('ProjectsService',
-    function($location, $q, AuthService, DataService, annotationNameFilter, AuthorizationService) {
+    function($location, $q, AuthService, DataService, annotationNameFilter, AuthorizationService, RecentlyViewedProjectsService) {
 
 
       var cleanEditableAnnotations = function(resource) {
@@ -37,6 +37,7 @@ angular.module('openshiftCommonServices')
                                         .then(function() {
                                           context.project = project;
                                           context.projectPromise.resolve(project);
+                                          RecentlyViewedProjectsService.addProjectUID(project.metadata.uid);
                                           // TODO: fix need to return context & projectPromise
                                           return [project, context];
                                         });
@@ -66,6 +67,23 @@ angular.module('openshiftCommonServices')
           update: function(projectName, data) {
             return DataService
                     .update('projects', projectName, cleanEditableAnnotations(data), {projectName: projectName}, {errorNotification: false});
+          },
+          create: function(name, displayName, description) {
+            var projectRequest = {
+              apiVersion: "v1",
+              kind: "ProjectRequest",
+              metadata: {
+                name: name
+              },
+              displayName: displayName,
+              description: description
+            };
+            return DataService
+              .create('projectrequests', null, projectRequest, {})
+              .then(function(project) {
+                RecentlyViewedProjectsService.addProjectUID(project.metadata.uid);
+                return project;
+              });
           },
           canCreate: function() {
             return DataService.get("projectrequests", null, {}, { errorNotification: false});

--- a/src/services/recentlyViewedProjects.js
+++ b/src/services/recentlyViewedProjects.js
@@ -1,0 +1,63 @@
+'use strict';
+
+angular.module("openshiftCommonServices")
+  .service("RecentlyViewedProjectsService", function($filter){
+
+    var recentlyViewedProjsKey = "openshift/recently-viewed-project-uids";
+
+    var getProjectUIDs = function() {
+      var recentlyViewed = localStorage.getItem(recentlyViewedProjsKey);
+      return recentlyViewed ? JSON.parse(recentlyViewed) : [];
+    };
+
+    var addProjectUID = function(uid) {
+      var recentlyViewed = getProjectUIDs();
+
+      // add to front of list
+      recentlyViewed.unshift(uid);
+
+      // no dups
+      recentlyViewed = _.uniq(recentlyViewed);
+
+      // limit to 5 items
+      recentlyViewed = _.take(recentlyViewed, 5);
+
+      setRecentlyViewedProjects(recentlyViewed);
+    };
+
+    var clear = function() {
+      localStorage.removeItem(recentlyViewedProjsKey);
+    };
+
+    var setRecentlyViewedProjects = function(recentlyViewed) {
+      localStorage.setItem(recentlyViewedProjsKey, JSON.stringify(recentlyViewed));
+    };
+
+    var orderByMostRecentlyViewed = function(projects) {
+      var recentlyViewedProjects = [];
+      var recentlyViewedIds = getProjectUIDs();
+
+      // remove mostRecentlyViewed projects
+      _.each(recentlyViewedIds, function(uid) {
+        var proj = _.remove(projects, function(project) {
+          return project.metadata.uid === uid;
+        })[0];
+        if(proj !== undefined) {
+          recentlyViewedProjects.push(proj);
+        }
+      });
+
+      // order by creationDate
+      projects =  $filter('orderObjectsByDate')(projects, true);
+
+      // return array where moveRecentlyViewed is first, then sorted by creationDate
+      return recentlyViewedProjects.concat(projects);
+    };
+
+    return {
+      getProjectUIDs: getProjectUIDs,
+      addProjectUID: addProjectUID,
+      orderByMostRecentlyViewed: orderByMostRecentlyViewed,
+      clear: clear
+    };
+  });

--- a/test/spec/services/recentlyViewedProjectsServiceSpec.js
+++ b/test/spec/services/recentlyViewedProjectsServiceSpec.js
@@ -1,0 +1,92 @@
+"use strict";
+
+describe("RecentlyViewedProjectsService", function(){
+  var RecentlyViewedProjectsService;
+
+  beforeEach(function(){
+    inject(function(_RecentlyViewedProjectsService_){
+      RecentlyViewedProjectsService = _RecentlyViewedProjectsService_;
+    });
+  });
+
+  afterEach(function(){
+    RecentlyViewedProjectsService.clear();
+  });
+
+  it('should retrieve projects as Last-In-First-Out', function() {
+    RecentlyViewedProjectsService.addProjectUID("001");
+    RecentlyViewedProjectsService.addProjectUID("002");
+    RecentlyViewedProjectsService.addProjectUID("003");
+
+    var recentlyViewed = RecentlyViewedProjectsService.getProjectUIDs();
+
+    expect(recentlyViewed.length).toEqual(3);
+    expect(recentlyViewed[0]).toEqual('003');
+    expect(recentlyViewed[1]).toEqual('002');
+    expect(recentlyViewed[2]).toEqual('001');
+  });
+
+  it('should limit recently viewed projects to 5', function() {
+    RecentlyViewedProjectsService.addProjectUID("001");
+    RecentlyViewedProjectsService.addProjectUID("002");
+    RecentlyViewedProjectsService.addProjectUID("003");
+    RecentlyViewedProjectsService.addProjectUID("004");
+    RecentlyViewedProjectsService.addProjectUID("005");
+    RecentlyViewedProjectsService.addProjectUID("006");
+    RecentlyViewedProjectsService.addProjectUID("007");
+
+    var recentlyViewed = RecentlyViewedProjectsService.getProjectUIDs();
+    expect(recentlyViewed.length).toEqual(5);
+  });
+
+  it('should move an already recently viewed project to first in list', function() {
+    RecentlyViewedProjectsService.addProjectUID("001");
+    RecentlyViewedProjectsService.addProjectUID("002");
+    RecentlyViewedProjectsService.addProjectUID("003");  // '003' in list
+    RecentlyViewedProjectsService.addProjectUID("004");
+    RecentlyViewedProjectsService.addProjectUID("003");  // '003' should be first and not added twice
+
+    // LIFO should be 003, 004, 002, 001
+    var recentlyViewed = RecentlyViewedProjectsService.getProjectUIDs();
+    expect(recentlyViewed.length).toEqual(4);
+    expect(recentlyViewed[0]).toEqual('003');
+    expect(recentlyViewed[3]).toEqual('001');
+  });
+
+  it('should orderByMostRecentlyViewed', function() {
+    // simulates a project list sorted by creationTimestamp, where projects created
+    // in order 1-5, 5 being the most recently created.
+    var projects = [
+      {"metadata": {"uid": "005", "creationTimestamp": "2017-05-21T20:52:10Z"}},
+      {"metadata": {"uid": "004", "creationTimestamp": "2017-04-21T20:52:10Z"}},
+      {"metadata": {"uid": "003", "creationTimestamp": "2017-03-21T20:52:10Z"}},
+      {"metadata": {"uid": "002", "creationTimestamp": "2017-02-21T20:52:10Z"}},
+      {"metadata": {"uid": "001", "creationTimestamp": "2017-01-21T20:52:10Z"}}
+    ];
+
+    // simulates projects 1,3,4 being most recently viewed
+    RecentlyViewedProjectsService.addProjectUID("007"); // simulate a recently viewed which is not in project list (diff user)
+    RecentlyViewedProjectsService.addProjectUID("001");
+    RecentlyViewedProjectsService.addProjectUID("003");
+    RecentlyViewedProjectsService.addProjectUID("004");
+
+    var recentlyViewed = RecentlyViewedProjectsService.getProjectUIDs();
+    expect(recentlyViewed.length).toEqual(4);
+    expect(recentlyViewed[0]).toEqual('004');
+    expect(recentlyViewed[1]).toEqual('003');
+    expect(recentlyViewed[2]).toEqual('001');
+    expect(recentlyViewed[3]).toEqual('007');
+
+    var sortedProjects = RecentlyViewedProjectsService.orderByMostRecentlyViewed(projects);
+
+    var expectedSort = [
+      {"metadata": {"uid": "004", "creationTimestamp": "2017-04-21T20:52:10Z"}},
+      {"metadata": {"uid": "003", "creationTimestamp": "2017-03-21T20:52:10Z"}},
+      {"metadata": {"uid": "001", "creationTimestamp": "2017-01-21T20:52:10Z"}},
+      {"metadata": {"uid": "005", "creationTimestamp": "2017-05-21T20:52:10Z"}},
+      {"metadata": {"uid": "002", "creationTimestamp": "2017-02-21T20:52:10Z"}}
+    ];
+
+    expect(sortedProjects).toEqual(expectedSort);
+  });
+});


### PR DESCRIPTION
Added RecentlyViewedProjectsService which uses localStorage to persist recently viewed project uids.   Updated `ProjectsService.get(projectName)` to save project's uid in RecentlyViewedProjectsService.  Added  `ProjectsService.create(...)`
Unit tests included.
This is the first PR towards resolving issue [console:#1895](https://github.com/openshift/origin-web-console/issues/1895)