### PR TITLE
Harding uri.js dependency, avoid 1.18.11+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "kubernetes-label-selector": "~2.0.0",
     "lodash": "~4.17.4",
     "patternfly": "~3.26.1",
-    "uri.js": "~1.18.0"
+    "uri.js": "<=1.18.10"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.11",


### PR DESCRIPTION
uri.js 1.18.11 requires Number.isInteger which is not supported by all of our supported browsers.