### PR TITLE
Allow OAuth scope(s) to be configured

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -3081,6 +3081,7 @@ angular.module('openshiftCommonServices')
   var _oauth_authorize_uri = "";
   var _oauth_token_uri = "";
   var _oauth_redirect_uri = "";
+  var _oauth_scope = "";
 
   this.OAuthClientID = function(id) {
     if (id) {
@@ -3106,6 +3107,12 @@ angular.module('openshiftCommonServices')
     }
     return _oauth_redirect_uri;
   };
+  this.OAuthScope = function(scope) {
+    if (scope) {
+      _oauth_scope = scope;
+    }
+    return _oauth_scope;
+  }
 
   this.$get = function($injector, $location, $q, Logger, base64) {
     var authLogger = Logger.get("auth");
@@ -3195,6 +3202,10 @@ angular.module('openshiftCommonServices')
           state: makeState(returnUri.toString()),
           redirect_uri: _oauth_redirect_uri
         };
+
+        if (_oauth_scope) {
+          authorizeParams.scope = _oauth_scope;
+        }
 
         if (_oauth_token_uri) {
           authorizeParams.response_type = "code";
@@ -3286,6 +3297,10 @@ angular.module('openshiftCommonServices')
             "redirect_uri=" + encodeURIComponent(_oauth_redirect_uri),
             "client_id="    + encodeURIComponent(_oauth_client_id)
           ].join("&");
+
+          if (_oauth_scope) {
+            tokenPostData += "&scope=" + encodeURIComponent(_oauth_scope);
+          }
 
           return http({
             method: "POST",

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -4949,6 +4949,7 @@ angular.module('openshiftCommonServices')
   var _oauth_authorize_uri = "";
   var _oauth_token_uri = "";
   var _oauth_redirect_uri = "";
+  var _oauth_scope = "";
 
   this.OAuthClientID = function(id) {
     if (id) {
@@ -4974,6 +4975,12 @@ angular.module('openshiftCommonServices')
     }
     return _oauth_redirect_uri;
   };
+  this.OAuthScope = function(scope) {
+    if (scope) {
+      _oauth_scope = scope;
+    }
+    return _oauth_scope;
+  }
 
   this.$get = ["$injector", "$location", "$q", "Logger", "base64", function($injector, $location, $q, Logger, base64) {
     var authLogger = Logger.get("auth");
@@ -5063,6 +5070,10 @@ angular.module('openshiftCommonServices')
           state: makeState(returnUri.toString()),
           redirect_uri: _oauth_redirect_uri
         };
+
+        if (_oauth_scope) {
+          authorizeParams.scope = _oauth_scope;
+        }
 
         if (_oauth_token_uri) {
           authorizeParams.response_type = "code";
@@ -5154,6 +5165,10 @@ angular.module('openshiftCommonServices')
             "redirect_uri=" + encodeURIComponent(_oauth_redirect_uri),
             "client_id="    + encodeURIComponent(_oauth_client_id)
           ].join("&");
+
+          if (_oauth_scope) {
+            tokenPostData += "&scope=" + encodeURIComponent(_oauth_scope);
+          }
 
           return http({
             method: "POST",

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -2074,7 +2074,7 @@ orderByMostRecentlyViewed:orderByMostRecentlyViewed,
 clear:clear
 };
 } ]), angular.module("openshiftCommonServices").provider("RedirectLoginService", function() {
-var _oauth_client_id = "", _oauth_authorize_uri = "", _oauth_token_uri = "", _oauth_redirect_uri = "";
+var _oauth_client_id = "", _oauth_authorize_uri = "", _oauth_token_uri = "", _oauth_redirect_uri = "", _oauth_scope = "";
 this.OAuthClientID = function(id) {
 return id && (_oauth_client_id = id), _oauth_client_id;
 }, this.OAuthAuthorizeURI = function(uri) {
@@ -2083,6 +2083,8 @@ return uri && (_oauth_authorize_uri = uri), _oauth_authorize_uri;
 return uri && (_oauth_token_uri = uri), _oauth_token_uri;
 }, this.OAuthRedirectURI = function(uri) {
 return uri && (_oauth_redirect_uri = uri), _oauth_redirect_uri;
+}, this.OAuthScope = function(scope) {
+return scope && (_oauth_scope = scope), _oauth_scope;
 }, this.$get = [ "$injector", "$location", "$q", "Logger", "base64", function($injector, $location, $q, Logger, base64) {
 var authLogger = Logger.get("auth"), getRandomInts = function(length) {
 var randomValues;
@@ -2147,7 +2149,7 @@ response_type:"token",
 state:makeState(returnUri.toString()),
 redirect_uri:_oauth_redirect_uri
 };
-_oauth_token_uri && (authorizeParams.response_type = "code");
+_oauth_scope && (authorizeParams.scope = _oauth_scope), _oauth_token_uri && (authorizeParams.response_type = "code");
 var deferred = $q.defer(), uri = new URI(_oauth_authorize_uri);
 return uri.query(authorizeParams), authLogger.log("RedirectLoginService.login(), redirecting", uri.toString()), window.location.href = uri.toString(), deferred.promise;
 },
@@ -2177,7 +2179,7 @@ error:"invalid_request",
 error_description:"Client state could not be verified"
 });
 var tokenPostData = [ "grant_type=authorization_code", "code=" + encodeURIComponent(queryParams.code), "redirect_uri=" + encodeURIComponent(_oauth_redirect_uri), "client_id=" + encodeURIComponent(_oauth_client_id) ].join("&");
-return http({
+return _oauth_scope && (tokenPostData += "&scope=" + encodeURIComponent(_oauth_scope)), http({
 method:"POST",
 url:_oauth_token_uri,
 headers:{

--- a/src/services/redirectLoginService.js
+++ b/src/services/redirectLoginService.js
@@ -7,6 +7,7 @@ angular.module('openshiftCommonServices')
   var _oauth_authorize_uri = "";
   var _oauth_token_uri = "";
   var _oauth_redirect_uri = "";
+  var _oauth_scope = "";
 
   this.OAuthClientID = function(id) {
     if (id) {
@@ -32,6 +33,12 @@ angular.module('openshiftCommonServices')
     }
     return _oauth_redirect_uri;
   };
+  this.OAuthScope = function(scope) {
+    if (scope) {
+      _oauth_scope = scope;
+    }
+    return _oauth_scope;
+  }
 
   this.$get = function($injector, $location, $q, Logger, base64) {
     var authLogger = Logger.get("auth");
@@ -121,6 +128,10 @@ angular.module('openshiftCommonServices')
           state: makeState(returnUri.toString()),
           redirect_uri: _oauth_redirect_uri
         };
+
+        if (_oauth_scope) {
+          authorizeParams.scope = _oauth_scope;
+        }
 
         if (_oauth_token_uri) {
           authorizeParams.response_type = "code";
@@ -212,6 +223,10 @@ angular.module('openshiftCommonServices')
             "redirect_uri=" + encodeURIComponent(_oauth_redirect_uri),
             "client_id="    + encodeURIComponent(_oauth_client_id)
           ].join("&");
+
+          if (_oauth_scope) {
+            tokenPostData += "&scope=" + encodeURIComponent(_oauth_scope);
+          }
 
           return http({
             method: "POST",


### PR DESCRIPTION
Add `OAuthScope` getter/setter to the RedirectLoginService.
This change allows specifying the 'scope' parameter when requesting an
authorization code & token.
This is necessary if using an OAuth client that doesn't allow requesting
tokens with the default 'user:full' scope.
e.g. A ServiceAccount OAuth Client https://docs.openshift.com/container-platform/3.6/architecture/additional_concepts/authentication.html#service-accounts-as-oauth-clients

*Example Usage*

```js
angular
  .module('myApp', [
    'openshiftCommonServices'
  ])
  .config(['RedirectLoginServiceProvider', function (RedirectLoginServiceProvider) {
      RedirectLoginServiceProvider.OAuthScope('user:info user:check-access');
  }])
```