### PR TITLE
Add watch task to automatically run "deploy" task when files in /src change

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,15 @@ module.exports = function (grunt) {
           }
         }
       },
+      watch: {
+        scripts: {
+          files: ['src/**/*'],
+          tasks: ['deploy'],
+          options: {
+            spawn: false,
+          },
+        },
+      },
       clean: {
         all: ['dist/*']
       },


### PR DESCRIPTION
If you `bower link` this repo & intend to do some dev while using `origin-web-console` for the feedback loop, its handy to be able to run `grunt watch` so that the build/dist is automatically run on changes.

@spadgett @jeff-phillips-18 
