### PR TITLE
Add `watch` to package.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,8 @@ module.exports = function (grunt) {
               'help': 'Task list helper for your Grunt enabled projects.',
               'clean': 'Deletes the content of the dist directory.',
               'build': 'Builds the project into the dist directory.',
-              'test': 'Executes the karma testsuite.'
+              'test': 'Executes the karma testsuite.',
+              'watch': 'Automatically rebuild /dist whenever /src files change.'
             },
             groups: {
               'Basic project tasks': ['help', 'clean', 'build', 'test']

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test": "grunt test",
     "build": "grunt build",
     "deploy": "grunt deploy",
+    "watch": "grunt watch",
     "help": "grunt help"
   },
   "repository": {


### PR DESCRIPTION
Probably should have added this when I added the watch task, so can `npm run watch` or `grunt watch`.

@jeff-phillips-18 @spadgett 