### PR TITLE
Null out handle in DataService.unwatch

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -1995,6 +1995,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       this._watchInFlight(key, false);
       this._watchOptions(key, null);
     }
+    handle = null;
   };
 
   // Takes an array of watch handles and unwatches them

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -3865,6 +3865,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       this._watchInFlight(key, false);
       this._watchOptions(key, null);
     }
+    handle = null;
   };
 
   // Takes an array of watch handles and unwatches them

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1581,6 +1581,7 @@ ws.shouldClose = !0, ws.close(), this._watchWebsockets(key, null);
 }
 this._watchInFlight(key, !1), this._watchOptions(key, null);
 }
+handle = null;
 }, DataService.prototype.unwatchAll = function(handles) {
 for (var i = 0; i < handles.length; i++) this.unwatch(handles[i]);
 }, DataService.prototype._watchCallbacks = function(key) {

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -772,6 +772,7 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
       this._watchInFlight(key, false);
       this._watchOptions(key, null);
     }
+    handle = null;
   };
 
   // Takes an array of watch handles and unwatches them


### PR DESCRIPTION
Per [this comment](https://github.com/openshift/origin-web-console/pull/2001#discussion_r136979769) & after doing the `null` manually in a few places, thinking we can update `DataService` with this little tweak.

@spadgett 