### PR TITLE
Bump version to 0.0.53

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-web-common",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "main": [
     "dist/origin-web-common.js",
     "dist/origin-web-common.css"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Red Hat",
   "name": "origin-web-common",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "license": "Apache-2.0",
   "description": "Library of common services and components for OpenShift Web Console.",
   "homepage": "https://github.com/openshift/origin-web-common.git",


### PR DESCRIPTION
Necessary for [web console 2001](https://github.com/openshift/origin-web-console/pull/2001) to work correctly. 

Anything else going in today?

@spadgett @jeff-phillips-18 @dtaylor113 