### PR TITLE
Improve notification id

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -2149,7 +2149,7 @@ angular.module('openshiftCommonUI').provider('NotificationsService', function() 
     };
 
     var addNotification = function (notification) {
-      notification.id = notification.id || _.uniqueId('notification-');
+      notification.id = notification.id || _.uniqueId('notification-') + Date.now();
       notification.timestamp = new Date().toISOString();
       if (isNotificationPermanentlyHidden(notification) || isNotificationVisible(notification)) {
         return;

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -5720,7 +5720,7 @@ angular.module('openshiftCommonUI').provider('NotificationsService', function() 
     };
 
     var addNotification = function (notification) {
-      notification.id = notification.id || _.uniqueId('notification-');
+      notification.id = notification.id || _.uniqueId('notification-') + Date.now();
       notification.timestamp = new Date().toISOString();
       if (isNotificationPermanentlyHidden(notification) || isNotificationVisible(notification)) {
         return;

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -2415,7 +2415,7 @@ this.dismissDelay = 8e3, this.autoDismissTypes = [ "info", "success" ], this.$ge
 var notifications = [], dismissDelay = this.dismissDelay, autoDismissTypes = this.autoDismissTypes, notificationHiddenKey = function(notificationID, namespace) {
 return namespace ? "hide/notification/" + namespace + "/" + notificationID :"hide/notification/" + notificationID;
 }, addNotification = function(notification) {
-notification.id = notification.id || _.uniqueId("notification-"), notification.timestamp = new Date().toISOString(), isNotificationPermanentlyHidden(notification) || isNotificationVisible(notification) || (notifications.push(notification), $rootScope.$emit("NotificationsService.onNotificationAdded", notification));
+notification.id = notification.id || _.uniqueId("notification-") + Date.now(), notification.timestamp = new Date().toISOString(), isNotificationPermanentlyHidden(notification) || isNotificationVisible(notification) || (notifications.push(notification), $rootScope.$emit("NotificationsService.onNotificationAdded", notification));
 }, hideNotification = function(notificationID) {
 notificationID && _.each(notifications, function(notification) {
 notification.id === notificationID && (notification.hidden = !0);

--- a/src/ui-services/notificationsService.js
+++ b/src/ui-services/notificationsService.js
@@ -18,7 +18,7 @@ angular.module('openshiftCommonUI').provider('NotificationsService', function() 
     };
 
     var addNotification = function (notification) {
-      notification.id = notification.id || _.uniqueId('notification-');
+      notification.id = notification.id || _.uniqueId('notification-') + Date.now();
       notification.timestamp = new Date().toISOString();
       if (isNotificationPermanentlyHidden(notification) || isNotificationVisible(notification)) {
         return;


### PR DESCRIPTION
- _.uniqueId() is not sufficient since the ID is used to persist some data
  for notifications via session storage.  The id generated starts at a low
  number & increments w/o randomness.
- Using _.uniqueId() along with Date.now() adds a random value that cannot
  be replicated across sessions/refresh

Example: with uniqueIds like `notification_1`, `notification_2` it is relatively easy for a notification to be marked `read`, but following a `refresh` having `read` be applied to a completely different notification. 

Needed for Notification Drawer updates [web console PR 2001](https://github.com/openshift/origin-web-console/pull/2001).  

@spadgett @jeff-phillips-18 
