### PR TITLE
Use label selectors in ApplicationsService

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -555,7 +555,37 @@ angular.module('openshiftCommonServices')
 ;'use strict';
 
 angular.module("openshiftCommonServices").
-service("ApplicationsService", function($filter, $q, DataService) {
+service("ApplicationsService", function($q, DataService) {
+
+  // List replication controllers in a namespace that are NOT managed by a
+  // deployment config. Note: This will not return replication controllers that
+  // have been orphaned by `oc delete dc/foo --cascade=false`.
+  var listStandaloneReplicationControllers = function(context) {
+    return DataService.list('replicationcontrollers', context, {
+      http: {
+        params: {
+          // If the replica set has a `openshift.io/deployment-config-name`
+          // label, it's managed by a deployment config.
+          labelSelector: "!openshift.io/deployment-config-name"
+        }
+      }
+    });
+  };
+
+  // List replica sets in a namespace that are NOT managed by a deployment.
+  // Note: This will not return replica sets that have been orphaned by
+  // `oc delete deployment/foo --cascade=false`.
+  var listStandaloneReplicaSets = function(context) {
+    return DataService.list({group: 'extensions', resource: 'replicasets'}, context, {
+      http: {
+        params: {
+          // If the replica set has a `pod-template-hash` label, it's managed
+          // by a deployment.
+          labelSelector: "!pod-template-hash"
+        }
+      }
+    });
+  };
 
   var getApplications = function(context) {
     var deferred = $q.defer();
@@ -563,16 +593,16 @@ service("ApplicationsService", function($filter, $q, DataService) {
 
     // Load all the "application" types
     promises.push(DataService.list('deploymentconfigs', context));
-    promises.push(DataService.list('replicationcontrollers', context));
+    promises.push(listStandaloneReplicationControllers(context));
     promises.push(DataService.list({group: 'apps', resource: 'deployments'}, context));
-    promises.push(DataService.list({group: 'extensions', resource: 'replicasets'}, context));
+    promises.push(listStandaloneReplicaSets(context));
     promises.push(DataService.list({group: 'apps', resource: 'statefulsets'}, context));
 
     $q.all(promises).then(_.spread(function(deploymentConfigData, replicationControllerData, deploymentData, replicaSetData, statefulSetData) {
       var deploymentConfigs = _.toArray(deploymentConfigData.by('metadata.name'));
-      var replicationControllers = _.reject(replicationControllerData.by('metadata.name'), $filter('hasDeploymentConfig'));
+      var replicationControllers = _.toArray(replicationControllerData.by('metadata.name'));
       var deployments = _.toArray(deploymentData.by('metadata.name'));
-      var replicaSets = _.reject(replicaSetData.by('metadata.name'), $filter('hasDeployment'));
+      var replicaSets = _.toArray(replicaSetData.by('metadata.name'));
       var statefulSets = _.toArray(statefulSetData.by('metadata.name'));
 
       var apiObjects = deploymentConfigs.concat(deployments)
@@ -588,6 +618,8 @@ service("ApplicationsService", function($filter, $q, DataService) {
   };
 
   return {
+    listStandaloneReplicationControllers: listStandaloneReplicationControllers,
+    listStandaloneReplicaSets: listStandaloneReplicaSets,
     getApplications: getApplications
   };
 });

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -2435,7 +2435,37 @@ angular.module('openshiftCommonServices')
 ;'use strict';
 
 angular.module("openshiftCommonServices").
-service("ApplicationsService", ["$filter", "$q", "DataService", function($filter, $q, DataService) {
+service("ApplicationsService", ["$q", "DataService", function($q, DataService) {
+
+  // List replication controllers in a namespace that are NOT managed by a
+  // deployment config. Note: This will not return replication controllers that
+  // have been orphaned by `oc delete dc/foo --cascade=false`.
+  var listStandaloneReplicationControllers = function(context) {
+    return DataService.list('replicationcontrollers', context, {
+      http: {
+        params: {
+          // If the replica set has a `openshift.io/deployment-config-name`
+          // label, it's managed by a deployment config.
+          labelSelector: "!openshift.io/deployment-config-name"
+        }
+      }
+    });
+  };
+
+  // List replica sets in a namespace that are NOT managed by a deployment.
+  // Note: This will not return replica sets that have been orphaned by
+  // `oc delete deployment/foo --cascade=false`.
+  var listStandaloneReplicaSets = function(context) {
+    return DataService.list({group: 'extensions', resource: 'replicasets'}, context, {
+      http: {
+        params: {
+          // If the replica set has a `pod-template-hash` label, it's managed
+          // by a deployment.
+          labelSelector: "!pod-template-hash"
+        }
+      }
+    });
+  };
 
   var getApplications = function(context) {
     var deferred = $q.defer();
@@ -2443,16 +2473,16 @@ service("ApplicationsService", ["$filter", "$q", "DataService", function($filter
 
     // Load all the "application" types
     promises.push(DataService.list('deploymentconfigs', context));
-    promises.push(DataService.list('replicationcontrollers', context));
+    promises.push(listStandaloneReplicationControllers(context));
     promises.push(DataService.list({group: 'apps', resource: 'deployments'}, context));
-    promises.push(DataService.list({group: 'extensions', resource: 'replicasets'}, context));
+    promises.push(listStandaloneReplicaSets(context));
     promises.push(DataService.list({group: 'apps', resource: 'statefulsets'}, context));
 
     $q.all(promises).then(_.spread(function(deploymentConfigData, replicationControllerData, deploymentData, replicaSetData, statefulSetData) {
       var deploymentConfigs = _.toArray(deploymentConfigData.by('metadata.name'));
-      var replicationControllers = _.reject(replicationControllerData.by('metadata.name'), $filter('hasDeploymentConfig'));
+      var replicationControllers = _.toArray(replicationControllerData.by('metadata.name'));
       var deployments = _.toArray(deploymentData.by('metadata.name'));
-      var replicaSets = _.reject(replicaSetData.by('metadata.name'), $filter('hasDeployment'));
+      var replicaSets = _.toArray(replicaSetData.by('metadata.name'));
       var statefulSets = _.toArray(statefulSetData.by('metadata.name'));
 
       var apiObjects = deploymentConfigs.concat(deployments)
@@ -2468,6 +2498,8 @@ service("ApplicationsService", ["$filter", "$q", "DataService", function($filter
   };
 
   return {
+    listStandaloneReplicationControllers: listStandaloneReplicationControllers,
+    listStandaloneReplicaSets: listStandaloneReplicaSets,
     getApplications: getApplications
   };
 }]);

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -960,26 +960,44 @@ invalidObjectKindOrVersion:invalidObjectKindOrVersion,
 unsupportedObjectKindOrVersion:unsupportedObjectKindOrVersion,
 availableKinds:availableKinds
 };
-} ]), angular.module("openshiftCommonServices").service("ApplicationsService", [ "$filter", "$q", "DataService", function($filter, $q, DataService) {
-var getApplications = function(context) {
-var deferred = $q.defer(), promises = [];
-return promises.push(DataService.list("deploymentconfigs", context)), promises.push(DataService.list("replicationcontrollers", context)), promises.push(DataService.list({
-group:"apps",
-resource:"deployments"
-}, context)), promises.push(DataService.list({
+} ]), angular.module("openshiftCommonServices").service("ApplicationsService", [ "$q", "DataService", function($q, DataService) {
+var listStandaloneReplicationControllers = function(context) {
+return DataService.list("replicationcontrollers", context, {
+http:{
+params:{
+labelSelector:"!openshift.io/deployment-config-name"
+}
+}
+});
+}, listStandaloneReplicaSets = function(context) {
+return DataService.list({
 group:"extensions",
 resource:"replicasets"
-}, context)), promises.push(DataService.list({
+}, context, {
+http:{
+params:{
+labelSelector:"!pod-template-hash"
+}
+}
+});
+}, getApplications = function(context) {
+var deferred = $q.defer(), promises = [];
+return promises.push(DataService.list("deploymentconfigs", context)), promises.push(listStandaloneReplicationControllers(context)), promises.push(DataService.list({
+group:"apps",
+resource:"deployments"
+}, context)), promises.push(listStandaloneReplicaSets(context)), promises.push(DataService.list({
 group:"apps",
 resource:"statefulsets"
 }, context)), $q.all(promises).then(_.spread(function(deploymentConfigData, replicationControllerData, deploymentData, replicaSetData, statefulSetData) {
-var deploymentConfigs = _.toArray(deploymentConfigData.by("metadata.name")), replicationControllers = _.reject(replicationControllerData.by("metadata.name"), $filter("hasDeploymentConfig")), deployments = _.toArray(deploymentData.by("metadata.name")), replicaSets = _.reject(replicaSetData.by("metadata.name"), $filter("hasDeployment")), statefulSets = _.toArray(statefulSetData.by("metadata.name")), apiObjects = deploymentConfigs.concat(deployments).concat(replicationControllers).concat(replicaSets).concat(statefulSets);
+var deploymentConfigs = _.toArray(deploymentConfigData.by("metadata.name")), replicationControllers = _.toArray(replicationControllerData.by("metadata.name")), deployments = _.toArray(deploymentData.by("metadata.name")), replicaSets = _.toArray(replicaSetData.by("metadata.name")), statefulSets = _.toArray(statefulSetData.by("metadata.name")), apiObjects = deploymentConfigs.concat(deployments).concat(replicationControllers).concat(replicaSets).concat(statefulSets);
 deferred.resolve(_.sortBy(apiObjects, [ "metadata.name", "kind" ]));
 }), function(e) {
 deferred.reject(e);
 }), deferred.promise;
 };
 return {
+listStandaloneReplicationControllers:listStandaloneReplicationControllers,
+listStandaloneReplicaSets:listStandaloneReplicaSets,
 getApplications:getApplications
 };
 } ]), angular.module("openshiftCommonServices").provider("AuthService", function() {

--- a/src/services/applicationsService.js
+++ b/src/services/applicationsService.js
@@ -1,7 +1,37 @@
 'use strict';
 
 angular.module("openshiftCommonServices").
-service("ApplicationsService", function($filter, $q, DataService) {
+service("ApplicationsService", function($q, DataService) {
+
+  // List replication controllers in a namespace that are NOT managed by a
+  // deployment config. Note: This will not return replication controllers that
+  // have been orphaned by `oc delete dc/foo --cascade=false`.
+  var listStandaloneReplicationControllers = function(context) {
+    return DataService.list('replicationcontrollers', context, {
+      http: {
+        params: {
+          // If the replica set has a `openshift.io/deployment-config-name`
+          // label, it's managed by a deployment config.
+          labelSelector: "!openshift.io/deployment-config-name"
+        }
+      }
+    });
+  };
+
+  // List replica sets in a namespace that are NOT managed by a deployment.
+  // Note: This will not return replica sets that have been orphaned by
+  // `oc delete deployment/foo --cascade=false`.
+  var listStandaloneReplicaSets = function(context) {
+    return DataService.list({group: 'extensions', resource: 'replicasets'}, context, {
+      http: {
+        params: {
+          // If the replica set has a `pod-template-hash` label, it's managed
+          // by a deployment.
+          labelSelector: "!pod-template-hash"
+        }
+      }
+    });
+  };
 
   var getApplications = function(context) {
     var deferred = $q.defer();
@@ -9,16 +39,16 @@ service("ApplicationsService", function($filter, $q, DataService) {
 
     // Load all the "application" types
     promises.push(DataService.list('deploymentconfigs', context));
-    promises.push(DataService.list('replicationcontrollers', context));
+    promises.push(listStandaloneReplicationControllers(context));
     promises.push(DataService.list({group: 'apps', resource: 'deployments'}, context));
-    promises.push(DataService.list({group: 'extensions', resource: 'replicasets'}, context));
+    promises.push(listStandaloneReplicaSets(context));
     promises.push(DataService.list({group: 'apps', resource: 'statefulsets'}, context));
 
     $q.all(promises).then(_.spread(function(deploymentConfigData, replicationControllerData, deploymentData, replicaSetData, statefulSetData) {
       var deploymentConfigs = _.toArray(deploymentConfigData.by('metadata.name'));
-      var replicationControllers = _.reject(replicationControllerData.by('metadata.name'), $filter('hasDeploymentConfig'));
+      var replicationControllers = _.toArray(replicationControllerData.by('metadata.name'));
       var deployments = _.toArray(deploymentData.by('metadata.name'));
-      var replicaSets = _.reject(replicaSetData.by('metadata.name'), $filter('hasDeployment'));
+      var replicaSets = _.toArray(replicaSetData.by('metadata.name'));
       var statefulSets = _.toArray(statefulSetData.by('metadata.name'));
 
       var apiObjects = deploymentConfigs.concat(deployments)
@@ -34,6 +64,8 @@ service("ApplicationsService", function($filter, $q, DataService) {
   };
 
   return {
+    listStandaloneReplicationControllers: listStandaloneReplicationControllers,
+    listStandaloneReplicaSets: listStandaloneReplicaSets,
     getApplications: getApplications
   };
 });


### PR DESCRIPTION
Filter out replication controllers and replica sets that have owners using label selectors in calls to `DataService.list`. This is more efficient than filtering on the client.

Fixes #179