### PR TITLE
Do not center results-status icons

### DIFF
--- a/dist/less/_bind-service.less
+++ b/dist/less/_bind-service.less
@@ -83,7 +83,6 @@
 }
 
 .results-status {
-  align-items: center;
   display: flex;
   margin-bottom: 15px;
   .fa,

--- a/dist/origin-web-common.css
+++ b/dist/origin-web-common.css
@@ -101,7 +101,6 @@
   margin-bottom: 0;
 }
 .results-status {
-  align-items: center;
   display: flex;
   margin-bottom: 15px;
 }

--- a/src/styles/_bind-service.less
+++ b/src/styles/_bind-service.less
@@ -83,7 +83,6 @@
 }
 
 .results-status {
-  align-items: center;
   display: flex;
   margin-bottom: 15px;
   .fa,


### PR DESCRIPTION
Supports https://github.com/openshift/origin-web-console/issues/2232

<img width="931" alt="screen shot 2017-10-09 at 10 28 37 am" src="https://user-images.githubusercontent.com/895728/31343258-1b5fc8a8-acdd-11e7-9eab-a8d18b57193b.PNG">
<img width="496" alt="screen shot 2017-10-09 at 10 28 58 am" src="https://user-images.githubusercontent.com/895728/31343259-1b9c724e-acdd-11e7-8c28-5c102be8dbca.PNG">
