### PR TITLE
Update bower to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "angular": "1.5.11"
   },
   "devDependencies": {
-    "bower": "^1.8.0",
+    "bower": "^1.8.2",
     "express": "3.4.4",
     "grunt": "0.4.5",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
The https://bower.herokuapp.com registry is deprecated. We need to update Bower to switch to the new https://registry.bower.io URL.