### PR TITLE
Tighten down linkify URL matching

### DIFF
--- a/dist/origin-web-common-ui.js
+++ b/dist/origin-web-common-ui.js
@@ -2215,7 +2215,7 @@ angular.module("openshiftCommonUI")
         }
 
         // Replace any URLs with links.
-        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(str) {
+        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+[^\s<]*[^\s.,()\[\]{}<>"\u201d\u2019]/gm, function(str) {
           if (target) {
             return "<a href=\"" + str + "\" target=\"" + target + "\">" + str + " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>";
           }

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -5918,7 +5918,7 @@ angular.module("openshiftCommonUI")
         }
 
         // Replace any URLs with links.
-        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(str) {
+        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+[^\s<]*[^\s.,()\[\]{}<>"\u201d\u2019]/gm, function(str) {
           if (target) {
             return "<a href=\"" + str + "\" target=\"" + target + "\">" + str + " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>";
           }

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -2630,7 +2630,7 @@ return !0;
 }
 },
 linkify:function(text, target, alreadyEscaped) {
-return text ? (alreadyEscaped || (text = _.escape(text)), text.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(str) {
+return text ? (alreadyEscaped || (text = _.escape(text)), text.replace(/https?:\/\/[A-Za-z0-9._%+-]+[^\s<]*[^\s.,()\[\]{}<>"\u201d\u2019]/gm, function(str) {
 return target ? '<a href="' + str + '" target="' + target + '">' + str + ' <i class="fa fa-external-link" aria-hidden="true"></i></a>' :'<a href="' + str + '">' + str + "</a>";
 })) :text;
 }

--- a/src/ui-services/htmlService.js
+++ b/src/ui-services/htmlService.js
@@ -100,7 +100,7 @@ angular.module("openshiftCommonUI")
         }
 
         // Replace any URLs with links.
-        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+\S*[^\s.;,(){}<>"\u201d\u2019]/gm, function(str) {
+        return text.replace(/https?:\/\/[A-Za-z0-9._%+-]+[^\s<]*[^\s.,()\[\]{}<>"\u201d\u2019]/gm, function(str) {
           if (target) {
             return "<a href=\"" + str + "\" target=\"" + target + "\">" + str + " <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i></a>";
           }


### PR DESCRIPTION
Avoid additional punctuation being incorrectly included in our URL matching by tightening down the regex used by linkify.