### PR TITLE
Bug 1502574 - Don't fail on all discovery errors

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -54,7 +54,8 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
       API_DISCOVERY_ERRORS.push({
         data: data,
         textStatus: textStatus,
-        xhr: jqXHR
+        xhr: jqXHR,
+        fatal: true
       });
     });
 
@@ -68,7 +69,8 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
       API_DISCOVERY_ERRORS.push({
         data: data,
         textStatus: textStatus,
-        xhr: jqXHR
+        xhr: jqXHR,
+        fatal: true
       });
     });
 
@@ -128,26 +130,10 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
       API_DISCOVERY_ERRORS.push({
         data: data,
         textStatus: textStatus,
-        xhr: jqXHR
+        xhr: jqXHR,
+        fatal: true
       });
     });
-
-  // Additional servers can be defined for debugging and prototyping against new servers not yet served by the aggregator
-  // There can not be any conflicts in the groups/resources from these API servers.
-  var additionalDeferreds = [];
-  _.each(window.OPENSHIFT_CONFIG.additionalServers, function(server) {
-   var baseURL = (server.protocol ? (server.protocol + "://") : protocol) + server.hostPort + server.prefix;
-   additionalDeferreds.push($.get(baseURL)
-    .then(_.partial(getGroups, baseURL, server), function(data, textStatus, jqXHR) {
-      if (server.required !== false) {
-        API_DISCOVERY_ERRORS.push({
-          data: data,
-          textStatus: textStatus,
-          xhr: jqXHR
-        });
-      }
-    }));
-  });
 
   // Will be called on success or failure
   var discoveryFinished = function() {
@@ -164,7 +150,6 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
     osDeferred,
     apisDeferred
   ];
-  allDeferreds = allDeferreds.concat(additionalDeferreds);
   $.when.apply(this, allDeferreds).always(discoveryFinished);
 });
 
@@ -402,12 +387,26 @@ angular.module('openshiftCommonServices')
         AuthService.withUser();
         return;
       }
-      // Otherwise go to the error page, the server might be down.  Can't use Navigate.toErrorPage or it will create a circular dependency
-      $window.location.href = URI('error').query({
-        error_description: "Unable to load details about the server. If the problem continues, please contact your system administrator.",
-        error: "API_DISCOVERY"
-      }).toString();
-      return;
+      var fatal = false;
+      _.each(APIS_CFG.API_DISCOVERY_ERRORS, function(discoveryError) {
+        if (discoveryError.fatal) {
+          Logger.error('API discovery failed (fatal error)', discoveryError);
+          fatal = true;
+          return;
+        }
+
+        Logger.warn('API discovery failed', discoveryError);
+      });
+      if (fatal) {
+        // Go to the error page on fatal errors, the server might be down.
+        // Can't use Navigate.toErrorPage or it will create a circular
+        // dependency
+        $window.location.href = URI('error').query({
+          error_description: "Unable to load details about the server. If the problem continues, please contact your system administrator.",
+          error: "API_DISCOVERY"
+        }).toString();
+        return;
+      }
     }
 
     resource = toResourceGroupVersion(resource);
@@ -535,7 +534,7 @@ angular.module('openshiftCommonServices')
 
   // Provides us a way to ensure we consistently use the
   // correct {resource, group} for API calls.  Version
-  // will typically fallback to the preferredVersion of the API 
+  // will typically fallback to the preferredVersion of the API
   var getPreferredVersion = function(resource) {
     var preferred = API_PREFERRED_VERSIONS[resource];
     if(!preferred) {

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -17,7 +17,8 @@ api.k8s.v1 = _.keyBy(data.resources, "name");
 API_DISCOVERY_ERRORS.push({
 data:data,
 textStatus:textStatus,
-xhr:jqXHR
+xhr:jqXHR,
+fatal:!0
 });
 }), osBaseURL = protocol + window.OPENSHIFT_CONFIG.api.openshift.hostPort + window.OPENSHIFT_CONFIG.api.openshift.prefix, osDeferred = $.get(osBaseURL + "/v1").done(function(data) {
 api.openshift.v1 = _.keyBy(data.resources, "name");
@@ -25,7 +26,8 @@ api.openshift.v1 = _.keyBy(data.resources, "name");
 API_DISCOVERY_ERRORS.push({
 data:data,
 textStatus:textStatus,
-xhr:jqXHR
+xhr:jqXHR,
+fatal:!0
 });
 }), apisBaseURL = protocol + window.OPENSHIFT_CONFIG.apis.hostPort + window.OPENSHIFT_CONFIG.apis.prefix, getGroups = function(baseURL, hostPrefix, data) {
 var apisDeferredVersions = [];
@@ -56,23 +58,13 @@ xhr:jqXHR
 API_DISCOVERY_ERRORS.push({
 data:data,
 textStatus:textStatus,
-xhr:jqXHR
+xhr:jqXHR,
+fatal:!0
 });
-}), additionalDeferreds = [];
-_.each(window.OPENSHIFT_CONFIG.additionalServers, function(server) {
-var baseURL = (server.protocol ? server.protocol + "://" :protocol) + server.hostPort + server.prefix;
-additionalDeferreds.push($.get(baseURL).then(_.partial(getGroups, baseURL, server), function(data, textStatus, jqXHR) {
-server.required !== !1 && API_DISCOVERY_ERRORS.push({
-data:data,
-textStatus:textStatus,
-xhr:jqXHR
-});
-}));
-});
-var discoveryFinished = function() {
+}), discoveryFinished = function() {
 window.OPENSHIFT_CONFIG.api.k8s.resources = api.k8s, window.OPENSHIFT_CONFIG.api.openshift.resources = api.openshift, window.OPENSHIFT_CONFIG.apis.groups = apis, API_DISCOVERY_ERRORS.length && (window.OPENSHIFT_CONFIG.apis.API_DISCOVERY_ERRORS = API_DISCOVERY_ERRORS), next();
 }, allDeferreds = [ k8sDeferred, osDeferred, apisDeferred ];
-allDeferreds = allDeferreds.concat(additionalDeferreds), $.when.apply(this, allDeferreds).always(discoveryFinished);
+$.when.apply(this, allDeferreds).always(discoveryFinished);
 }), angular.module("openshiftCommonUI", []).constant("BREAKPOINTS", {
 screenXsMin:480,
 screenSmMin:768,
@@ -1059,7 +1051,11 @@ if (APIS_CFG.API_DISCOVERY_ERRORS) {
 var possibleCertFailure = _.every(APIS_CFG.API_DISCOVERY_ERRORS, function(error) {
 return 0 === _.get(error, "data.status");
 });
-return possibleCertFailure && !AuthService.isLoggedIn() ? void AuthService.withUser() :void ($window.location.href = URI("error").query({
+if (possibleCertFailure && !AuthService.isLoggedIn()) return void AuthService.withUser();
+var fatal = !1;
+if (_.each(APIS_CFG.API_DISCOVERY_ERRORS, function(discoveryError) {
+return discoveryError.fatal ? (Logger.error("API discovery failed (fatal error)", discoveryError), void (fatal = !0)) :void Logger.warn("API discovery failed", discoveryError);
+}), fatal) return void ($window.location.href = URI("error").query({
 error_description:"Unable to load details about the server. If the problem continues, please contact your system administrator.",
 error:"API_DISCOVERY"
 }).toString());

--- a/src/openshiftCommonServices.module.js
+++ b/src/openshiftCommonServices.module.js
@@ -54,7 +54,8 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
       API_DISCOVERY_ERRORS.push({
         data: data,
         textStatus: textStatus,
-        xhr: jqXHR
+        xhr: jqXHR,
+        fatal: true
       });
     });
 
@@ -68,7 +69,8 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
       API_DISCOVERY_ERRORS.push({
         data: data,
         textStatus: textStatus,
-        xhr: jqXHR
+        xhr: jqXHR,
+        fatal: true
       });
     });
 
@@ -128,26 +130,10 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
       API_DISCOVERY_ERRORS.push({
         data: data,
         textStatus: textStatus,
-        xhr: jqXHR
+        xhr: jqXHR,
+        fatal: true
       });
     });
-
-  // Additional servers can be defined for debugging and prototyping against new servers not yet served by the aggregator
-  // There can not be any conflicts in the groups/resources from these API servers.
-  var additionalDeferreds = [];
-  _.each(window.OPENSHIFT_CONFIG.additionalServers, function(server) {
-   var baseURL = (server.protocol ? (server.protocol + "://") : protocol) + server.hostPort + server.prefix;
-   additionalDeferreds.push($.get(baseURL)
-    .then(_.partial(getGroups, baseURL, server), function(data, textStatus, jqXHR) {
-      if (server.required !== false) {
-        API_DISCOVERY_ERRORS.push({
-          data: data,
-          textStatus: textStatus,
-          xhr: jqXHR
-        });
-      }
-    }));
-  });
 
   // Will be called on success or failure
   var discoveryFinished = function() {
@@ -164,7 +150,6 @@ hawtioPluginLoader.registerPreBootstrapTask(function(next) {
     osDeferred,
     apisDeferred
   ];
-  allDeferreds = allDeferreds.concat(additionalDeferreds);
   $.when.apply(this, allDeferreds).always(discoveryFinished);
 });
 

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -209,12 +209,26 @@ angular.module('openshiftCommonServices')
         AuthService.withUser();
         return;
       }
-      // Otherwise go to the error page, the server might be down.  Can't use Navigate.toErrorPage or it will create a circular dependency
-      $window.location.href = URI('error').query({
-        error_description: "Unable to load details about the server. If the problem continues, please contact your system administrator.",
-        error: "API_DISCOVERY"
-      }).toString();
-      return;
+      var fatal = false;
+      _.each(APIS_CFG.API_DISCOVERY_ERRORS, function(discoveryError) {
+        if (discoveryError.fatal) {
+          Logger.error('API discovery failed (fatal error)', discoveryError);
+          fatal = true;
+          return;
+        }
+
+        Logger.warn('API discovery failed', discoveryError);
+      });
+      if (fatal) {
+        // Go to the error page on fatal errors, the server might be down.
+        // Can't use Navigate.toErrorPage or it will create a circular
+        // dependency
+        $window.location.href = URI('error').query({
+          error_description: "Unable to load details about the server. If the problem continues, please contact your system administrator.",
+          error: "API_DISCOVERY"
+        }).toString();
+        return;
+      }
     }
 
     resource = toResourceGroupVersion(resource);
@@ -342,7 +356,7 @@ angular.module('openshiftCommonServices')
 
   // Provides us a way to ensure we consistently use the
   // correct {resource, group} for API calls.  Version
-  // will typically fallback to the preferredVersion of the API 
+  // will typically fallback to the preferredVersion of the API
   var getPreferredVersion = function(resource) {
     var preferred = API_PREFERRED_VERSIONS[resource];
     if(!preferred) {


### PR DESCRIPTION
Some errors are not fatal for API groups the console doesn't use.
We should log warnings for those errors and continue.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1502574
Fixes https://github.com/openshift/origin-web-console/issues/2014