### PR TITLE
Include details from failed DataService.list

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -2384,7 +2384,12 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
           self._listInFlight(key, false);
           var deferred = self._listDeferred(key);
           delete self._listDeferredMap[key];
-          deferred.reject(data, status, headers, config);
+          deferred.reject({
+            data: data,
+            status: status,
+            headers: headers,
+            config: config
+          });
 
           if (!_.get(opts, 'errorNotification', true)) {
             return;
@@ -2407,7 +2412,12 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
         self._listInFlight(key, false);
         var deferred = self._listDeferred(key);
         delete self._listDeferredMap[key];
-        deferred.reject(data, status, headers, config);
+        deferred.reject({
+          data: data,
+          status: status,
+          headers: headers,
+          config: config
+        });
 
         if (!_.get(opts, 'errorNotification', true)) {
           return;

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -4408,7 +4408,12 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
           self._listInFlight(key, false);
           var deferred = self._listDeferred(key);
           delete self._listDeferredMap[key];
-          deferred.reject(data, status, headers, config);
+          deferred.reject({
+            data: data,
+            status: status,
+            headers: headers,
+            config: config
+          });
 
           if (!_.get(opts, 'errorNotification', true)) {
             return;
@@ -4431,7 +4436,12 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
         self._listInFlight(key, false);
         var deferred = self._listDeferred(key);
         delete self._listDeferredMap[key];
-        deferred.reject(data, status, headers, config);
+        deferred.reject({
+          data: data,
+          status: status,
+          headers: headers,
+          config: config
+        });
 
         if (!_.get(opts, 'errorNotification', true)) {
           return;

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1910,7 +1910,12 @@ self._listOpComplete(key, resource, context, opts, data);
 }).error(function(data, status, headers, config) {
 self._listInFlight(key, !1);
 var deferred = self._listDeferred(key);
-delete self._listDeferredMap[key], deferred.reject(data, status, headers, config), _.get(opts, "errorNotification", !0) && showRequestError("Failed to list " + resource, status);
+delete self._listDeferredMap[key], deferred.reject({
+data:data,
+status:status,
+headers:headers,
+config:config
+}), _.get(opts, "errorNotification", !0) && showRequestError("Failed to list " + resource, status);
 });
 }) :$http({
 method:"GET",
@@ -1922,7 +1927,12 @@ self._listOpComplete(key, resource, context, opts, data);
 }).error(function(data, status, headers, config) {
 self._listInFlight(key, !1);
 var deferred = self._listDeferred(key);
-delete self._listDeferredMap[key], deferred.reject(data, status, headers, config), _.get(opts, "errorNotification", !0) && showRequestError("Failed to list " + resource, status);
+delete self._listDeferredMap[key], deferred.reject({
+data:data,
+status:status,
+headers:headers,
+config:config
+}), _.get(opts, "errorNotification", !0) && showRequestError("Failed to list " + resource, status);
 });
 }, DataService.prototype._listOpComplete = function(key, resource, context, opts, data) {
 data.items || console.warn("List request for " + resource + " returned a null items array.  This is an invalid API response.");

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -1011,7 +1011,12 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
           self._listInFlight(key, false);
           var deferred = self._listDeferred(key);
           delete self._listDeferredMap[key];
-          deferred.reject(data, status, headers, config);
+          deferred.reject({
+            data: data,
+            status: status,
+            headers: headers,
+            config: config
+          });
 
           if (!_.get(opts, 'errorNotification', true)) {
             return;
@@ -1034,7 +1039,12 @@ DataService.prototype.createStream = function(resource, name, context, opts, isR
         self._listInFlight(key, false);
         var deferred = self._listDeferred(key);
         delete self._listDeferredMap[key];
-        deferred.reject(data, status, headers, config);
+        deferred.reject({
+          data: data,
+          status: status,
+          headers: headers,
+          config: config
+        });
 
         if (!_.get(opts, 'errorNotification', true)) {
           return;


### PR DESCRIPTION
The promise returned from DataService.list did not include the HTTP
status code and other information. Return the same object and properties
as $http and other DataService deferreds.