### PR TITLE
Fix bugs sorting service instances

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -1305,19 +1305,12 @@ angular.module("openshiftCommonServices")
     };
 
     var sortServiceInstances = function(serviceInstances, serviceClasses) {
-      if (!serviceInstances && !serviceClasses) {
-        return null;
-      }
+      var getServiceClassDisplayName = function(serviceInstance) {
+        var serviceClassName = _.get(serviceInstance, 'spec.clusterServiceClassRef.name');
+        return _.get(serviceClasses, [serviceClassName, 'spec', 'externalMetadata', 'displayName']) || serviceInstance.spec.clusterServiceClassExternalName;
+      };
 
-      return _.sortBy(serviceInstances,
-        function(item) {
-          var serviceClassName = _.get(item, 'spec.clusterServiceClassRef.name');
-          return _.get(serviceClasses, [serviceClassName, 'spec', 'externalMetadata', 'displayName']) || item.spec.clusterServiceClassExternalName;
-        },
-        function(item) {
-          return _.get(item, 'metadata.name', '');
-        }
-      );
+      return _.sortBy(serviceInstances, [ getServiceClassDisplayName, 'metadata.name' ]);
     };
 
     return {

--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -3272,6 +3272,60 @@ angular.module('openshiftCommonServices')
     });
 ;'use strict';
 
+angular.module('openshiftCommonServices')
+  .factory('PromiseUtils', function($q) {
+    return {
+      // Returns a promise that is resolved or rejected only after all promises
+      // complete. `promises` is a collection of promises. `null` or
+      // `undefined` values are treated as "complete."
+      //
+      // Different than `$q.all` in that it will always wait for all promises.
+      // `$q.all` short circuits as soon as one fails.
+      //
+      // Also unlike `$q.all`, this method does not return any values when
+      // resolving or reasons when rejecting the promise.
+      waitForAll: function(promises) {
+        var total = _.size(promises);
+        if (!total) {
+          return $q.when();
+        }
+
+        var deferred = $q.defer();
+        var complete = 0;
+        var failed = false;
+        var checkDone = function() {
+          if (complete < total) {
+            return;
+          }
+
+          if (failed) {
+            deferred.reject();
+          } else {
+            deferred.resolve();
+          }
+        };
+
+        _.each(promises, function(promise) {
+          if (!promise) {
+            complete++;
+            checkDone();
+            return;
+          }
+
+          promise.catch(function() {
+            failed = true;
+          }).finally(function() {
+            complete++;
+            checkDone();
+          });
+        });
+
+        return deferred.promise;
+      }
+    };
+  });
+;'use strict';
+
 angular.module("openshiftCommonServices")
   .service("RecentlyViewedProjectsService", function($filter){
 

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -3329,19 +3329,12 @@ angular.module("openshiftCommonServices")
     };
 
     var sortServiceInstances = function(serviceInstances, serviceClasses) {
-      if (!serviceInstances && !serviceClasses) {
-        return null;
-      }
+      var getServiceClassDisplayName = function(serviceInstance) {
+        var serviceClassName = _.get(serviceInstance, 'spec.clusterServiceClassRef.name');
+        return _.get(serviceClasses, [serviceClassName, 'spec', 'externalMetadata', 'displayName']) || serviceInstance.spec.clusterServiceClassExternalName;
+      };
 
-      return _.sortBy(serviceInstances,
-        function(item) {
-          var serviceClassName = _.get(item, 'spec.clusterServiceClassRef.name');
-          return _.get(serviceClasses, [serviceClassName, 'spec', 'externalMetadata', 'displayName']) || item.spec.clusterServiceClassExternalName;
-        },
-        function(item) {
-          return _.get(item, 'metadata.name', '');
-        }
-      );
+      return _.sortBy(serviceInstances, [ getServiceClassDisplayName, 'metadata.name' ]);
     };
 
     return {

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -5296,6 +5296,60 @@ angular.module('openshiftCommonServices')
     }]);
 ;'use strict';
 
+angular.module('openshiftCommonServices')
+  .factory('PromiseUtils', ["$q", function($q) {
+    return {
+      // Returns a promise that is resolved or rejected only after all promises
+      // complete. `promises` is a collection of promises. `null` or
+      // `undefined` values are treated as "complete."
+      //
+      // Different than `$q.all` in that it will always wait for all promises.
+      // `$q.all` short circuits as soon as one fails.
+      //
+      // Also unlike `$q.all`, this method does not return any values when
+      // resolving or reasons when rejecting the promise.
+      waitForAll: function(promises) {
+        var total = _.size(promises);
+        if (!total) {
+          return $q.when();
+        }
+
+        var deferred = $q.defer();
+        var complete = 0;
+        var failed = false;
+        var checkDone = function() {
+          if (complete < total) {
+            return;
+          }
+
+          if (failed) {
+            deferred.reject();
+          } else {
+            deferred.resolve();
+          }
+        };
+
+        _.each(promises, function(promise) {
+          if (!promise) {
+            complete++;
+            checkDone();
+            return;
+          }
+
+          promise.catch(function() {
+            failed = true;
+          }).finally(function() {
+            complete++;
+            checkDone();
+          });
+        });
+
+        return deferred.promise;
+      }
+    };
+  }]);
+;'use strict';
+
 angular.module("openshiftCommonServices")
   .service("RecentlyViewedProjectsService", ["$filter", function($filter){
 

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1465,12 +1465,11 @@ var serviceClassName = _.get(serviceInstance, "spec.clusterServiceClassRef.name"
 return isServiceBindable(serviceInstance, serviceClasses[serviceClassName], servicePlans[servicePlanName]);
 }) :null;
 }, sortServiceInstances = function(serviceInstances, serviceClasses) {
-return serviceInstances || serviceClasses ? _.sortBy(serviceInstances, function(item) {
-var serviceClassName = _.get(item, "spec.clusterServiceClassRef.name");
-return _.get(serviceClasses, [ serviceClassName, "spec", "externalMetadata", "displayName" ]) || item.spec.clusterServiceClassExternalName;
-}, function(item) {
-return _.get(item, "metadata.name", "");
-}) :null;
+var getServiceClassDisplayName = function(serviceInstance) {
+var serviceClassName = _.get(serviceInstance, "spec.clusterServiceClassRef.name");
+return _.get(serviceClasses, [ serviceClassName, "spec", "externalMetadata", "displayName" ]) || serviceInstance.spec.clusterServiceClassExternalName;
+};
+return _.sortBy(serviceInstances, [ getServiceClassDisplayName, "metadata.name" ]);
 };
 return {
 bindingResource:bindingResource,

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -2343,6 +2343,23 @@ return cachedProjectData && cachedProjectData.update(project, "DELETED"), delete
 });
 }
 };
+} ]), angular.module("openshiftCommonServices").factory("PromiseUtils", [ "$q", function($q) {
+return {
+waitForAll:function(promises) {
+var total = _.size(promises);
+if (!total) return $q.when();
+var deferred = $q.defer(), complete = 0, failed = !1, checkDone = function() {
+total > complete || (failed ? deferred.reject() :deferred.resolve());
+};
+return _.each(promises, function(promise) {
+return promise ? void promise["catch"](function() {
+failed = !0;
+})["finally"](function() {
+complete++, checkDone();
+}) :(complete++, void checkDone());
+}), deferred.promise;
+}
+};
 } ]), angular.module("openshiftCommonServices").service("RecentlyViewedProjectsService", [ "$filter", function($filter) {
 var recentlyViewedProjsKey = "openshift/recently-viewed-project-uids", getProjectUIDs = function() {
 var recentlyViewed = localStorage.getItem(recentlyViewedProjsKey);

--- a/src/services/bindService.js
+++ b/src/services/bindService.js
@@ -188,19 +188,12 @@ angular.module("openshiftCommonServices")
     };
 
     var sortServiceInstances = function(serviceInstances, serviceClasses) {
-      if (!serviceInstances && !serviceClasses) {
-        return null;
-      }
+      var getServiceClassDisplayName = function(serviceInstance) {
+        var serviceClassName = _.get(serviceInstance, 'spec.clusterServiceClassRef.name');
+        return _.get(serviceClasses, [serviceClassName, 'spec', 'externalMetadata', 'displayName']) || serviceInstance.spec.clusterServiceClassExternalName;
+      };
 
-      return _.sortBy(serviceInstances,
-        function(item) {
-          var serviceClassName = _.get(item, 'spec.clusterServiceClassRef.name');
-          return _.get(serviceClasses, [serviceClassName, 'spec', 'externalMetadata', 'displayName']) || item.spec.clusterServiceClassExternalName;
-        },
-        function(item) {
-          return _.get(item, 'metadata.name', '');
-        }
-      );
+      return _.sortBy(serviceInstances, [ getServiceClassDisplayName, 'metadata.name' ]);
     };
 
     return {

--- a/src/services/promiseUtilsService.js
+++ b/src/services/promiseUtilsService.js
@@ -1,0 +1,54 @@
+'use strict';
+
+angular.module('openshiftCommonServices')
+  .factory('PromiseUtils', function($q) {
+    return {
+      // Returns a promise that is resolved or rejected only after all promises
+      // complete. `promises` is a collection of promises. `null` or
+      // `undefined` values are treated as "complete."
+      //
+      // Different than `$q.all` in that it will always wait for all promises.
+      // `$q.all` short circuits as soon as one fails.
+      //
+      // Also unlike `$q.all`, this method does not return any values when
+      // resolving or reasons when rejecting the promise.
+      waitForAll: function(promises) {
+        var total = _.size(promises);
+        if (!total) {
+          return $q.when();
+        }
+
+        var deferred = $q.defer();
+        var complete = 0;
+        var failed = false;
+        var checkDone = function() {
+          if (complete < total) {
+            return;
+          }
+
+          if (failed) {
+            deferred.reject();
+          } else {
+            deferred.resolve();
+          }
+        };
+
+        _.each(promises, function(promise) {
+          if (!promise) {
+            complete++;
+            checkDone();
+            return;
+          }
+
+          promise.catch(function() {
+            failed = true;
+          }).finally(function() {
+            complete++;
+            checkDone();
+          });
+        });
+
+        return deferred.promise;
+      }
+    };
+  });


### PR DESCRIPTION
* Fix call to `_.sortBy` so that we're correctly handling secondary sort.
* Add utility that always waits for all promises to complete (even if one has failed).

See https://github.com/openshift/origin-web-console/issues/2384
See https://github.com/openshift/origin-web-console/pull/2385
