### PR TITLE
Add jshint task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,8 @@ module.exports = function (grunt) {
         all: {
           src: [
             'Gruntfile.js',
-            'src/{,*/}*.js'
+            'src/{,*/}*.js',
+            'test/{,*/}*.js'
           ]
         }
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,8 @@ module.exports = function (grunt) {
               'clean': 'Deletes the content of the dist directory.',
               'build': 'Builds the project into the dist directory.',
               'test': 'Executes the karma testsuite.',
-              'watch': 'Automatically rebuild /dist whenever /src files change.'
+              'watch': 'Automatically rebuild /dist whenever /src files change.',
+              'jshint': 'Scan source JavaScript files for errors or potential problems'
             },
             groups: {
               'Basic project tasks': ['help', 'clean', 'build', 'test']
@@ -131,12 +132,33 @@ module.exports = function (grunt) {
           src: 'dist/origin-web-common.js',
           dest: 'dist/origin-web-common.min.js'
         }
+      },
+      jshint: {
+        options: {
+          jshintrc: '.jshintrc',
+          reporter: require('jshint-stylish')
+        },
+        all: {
+          src: [
+            'Gruntfile.js',
+            'src/{,*/}*.js'
+          ]
+        }
       }
     });
 
     // You can specify which modules to build as arguments of the build task.
     grunt.registerTask('build', 'Create bootstrap build files', function () {
-      grunt.task.run(['clean', 'ngtemplates', 'concat', 'copy', 'ngAnnotate', 'less', 'uglify:build', 'test']);
+      grunt.task.run([
+        'clean',
+        'ngtemplates', 'concat',
+        'copy',
+        'ngAnnotate',
+        'less',
+        'uglify:build',
+        'test',
+        'jshint'
+      ]);
     });
 
     // Runs all the tasks of build with the exception of tests

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-karma": "0.8.3",
     "grunt-ng-annotate": "^1.0.1",
     "grunt-remove": "^0.1.0",
+    "jshint-stylish": "0.2.0",
     "karma": "0.12.23",
     "karma-chrome-launcher": "0.1.4",
     "karma-coverage": "^1.1.1",


### PR DESCRIPTION
We forgot to add a `jshint` task to this repo.  The code has drifted a bit, got a good number of small errors & style consistency items to fix:

```bash
Running "jshint:all" (jshint) task

src/constants/apiPreferredVersions.js
  line 5    col 7   Expected 'appliedclusterresourcequotas' to have an indentation at 3 instead at 7.
  line 6    col 7   Expected 'builds' to have an indentation at 3 instead at 7.
  line 7    col 7   Expected 'builds/clone' to have an indentation at 3 instead at 7.
  line 8    col 7   Expected 'buildconfigs/instantiate' to have an indentation at 3 instead at 7.
  line 9    col 7   Expected 'buildconfigs' to have an indentation at 3 instead at 7.
  line 10   col 7   Expected 'configmaps' to have an indentation at 3 instead at 7.
  line 11   col 7   Expected 'clusterserviceclasses' to have an indentation at 3 instead at 7.
  line 12   col 7   Expected 'clusterserviceplans' to have an indentation at 3 instead at 7.
  line 13   col 7   Expected 'deployments' to have an indentation at 3 instead at 7.
  line 14   col 7   Expected 'deploymentconfigs' to have an indentation at 3 instead at 7.
  line 15   col 7   Expected 'deploymentconfigs/instantiate' to have an indentation at 3 instead at 7.
  line 16   col 7   Expected 'deploymentconfigs/rollback' to have an indentation at 3 instead at 7.
  line 17   col 7   Expected 'events' to have an indentation at 3 instead at 7.
  line 18   col 7   Expected 'horizontalpodautoscalers' to have an indentation at 3 instead at 7.
  line 19   col 7   Expected 'imagestreams' to have an indentation at 3 instead at 7.
  line 20   col 7   Expected 'imagestreamtags' to have an indentation at 3 instead at 7.
  line 21   col 7   Expected 'limitranges' to have an indentation at 3 instead at 7.
  line 22   col 7   Expected 'pods' to have an indentation at 3 instead at 7.
  line 23   col 7   Expected 'projects' to have an indentation at 3 instead at 7.
  line 24   col 7   Expected 'projectrequests' to have an indentation at 3 instead at 7.
  line 25   col 7   Expected 'persistentvolumeclaims' to have an indentation at 3 instead at 7.
  line 26   col 7   Expected 'replicasets' to have an indentation at 3 instead at 7.
  line 27   col 7   Expected 'replicationcontrollers' to have an indentation at 3 instead at 7.
  line 28   col 7   Expected 'resourcequotas' to have an indentation at 3 instead at 7.
  line 29   col 7   Expected 'rolebindings' to have an indentation at 3 instead at 7.
  line 30   col 7   Expected 'routes' to have an indentation at 3 instead at 7.
  line 31   col 7   Expected 'secrets' to have an indentation at 3 instead at 7.
  line 32   col 7   Expected 'selfsubjectrulesreviews' to have an indentation at 3 instead at 7.
  line 33   col 7   Expected 'services' to have an indentation at 3 instead at 7.
  line 34   col 7   Expected 'serviceaccounts' to have an indentation at 3 instead at 7.
  line 35   col 7   Expected 'servicebindings' to have an indentation at 3 instead at 7.
  line 36   col 7   Expected 'serviceinstances' to have an indentation at 3 instead at 7.
  line 37   col 7   Expected 'statefulsets' to have an indentation at 3 instead at 7.
  line 38   col 7   Expected 'templates' to have an indentation at 3 instead at 7.
  line 39   col 3   Expected '}' to have an indentation at 1 instead at 3.

src/openshiftCommonServices.module.js
  line 9    col 5   Missing "use strict" statement.
  line 15   col 5   Missing "use strict" statement.
  line 34   col 3   Missing "use strict" statement.

src/services/authService.js
  line 51   col 1   Mixed spaces and tabs.
  line 52   col 1   Mixed spaces and tabs.
  line 53   col 1   Mixed spaces and tabs.
  line 54   col 1   Mixed spaces and tabs.
  line 55   col 1   Mixed spaces and tabs.
  line 56   col 1   Mixed spaces and tabs.
  line 57   col 1   Mixed spaces and tabs.
  line 150  col 39  Expected '===' and instead saw '=='.

src/services/authorizationService.js
  line 8    col 11  Expected 'number' to have an indentation at 7 instead at 11.
  line 9    col 9   Expected '}' to have an indentation at 5 instead at 9.
  line 102  col 11  Expected '}' to have an indentation at 13 instead at 11.

src/services/base64util.js
  line 9    col 20  Expected 'return' to have an indentation at 13 instead at 20.
  line 10   col 20  Expected 'return' to have an indentation at 13 instead at 20.
  line 11   col 20  Expected 'return' to have an indentation at 13 instead at 20.
  line 12   col 20  Expected 'return' to have an indentation at 13 instead at 20.

src/services/dataService.js
  line 200  col 14  'data' is already defined.
  line 212  col 17  'headers' is already defined.
  line 480  col 1   Expected 'DataService' to have an indentation at 3 instead at 1.
  line 481  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 482  col 3   Expected 'resource' to have an indentation at 5 instead at 3.
  line 484  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 485  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 486  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 487  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 488  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 489  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 491  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 492  col 3   Expected 'var' to have an indentation at 5 instead at 3.
  line 493  col 6   Expected 'return' to have an indentation at 7 instead at 6.
  line 497  col 29  Expected 'url' to have an indentation at 21 instead at 29.
  line 498  col 29  Expected 'auth' to have an indentation at 21 instead at 29.
  line 499  col 29  Expected 'onopen' to have an indentation at 21 instead at 29.
  line 504  col 29  Expected 'onmessage' to have an indentation at 21 instead at 29.
  line 526  col 29  Expected 'onclose' to have an indentation at 21 instead at 29.
  line 531  col 29  Expected 'onerror' to have an indentation at 21 instead at 29.
  line 536  col 29  Expected 'protocols' to have an indentation at 21 instead at 29.
  line 537  col 27  Expected '}' to have an indentation at 19 instead at 27.
  line 542  col 3   Expected '}' to have an indentation at 5 instead at 3.
  line 543  col 3   Expected 'return' to have an indentation at 5 instead at 3.
  line 544  col 5   Expected 'onOpen' to have an indentation at 7 instead at 5.
  line 545  col 7   Expected 'if' to have an indentation at 9 instead at 7.
  line 546  col 9   Expected 'return' to have an indentation at 11 instead at 9.
  line 547  col 7   Expected '}' to have an indentation at 9 instead at 7.
  line 548  col 7   Expected 'var' to have an indentation at 9 instead at 7.
  line 549  col 7   Expected 'openQueue' to have an indentation at 9 instead at 7.
  line 550  col 7   Expected 'return' to have an indentation at 9 instead at 7.
  line 551  col 5   Expected '}' to have an indentation at 7 instead at 5.
  line 552  col 5   Expected 'onMessage' to have an indentation at 7 instead at 5.
  line 553  col 7   Expected 'if' to have an indentation at 9 instead at 7.
  line 554  col 9   Expected 'return' to have an indentation at 11 instead at 9.
  line 555  col 7   Expected '}' to have an indentation at 9 instead at 7.
  line 556  col 7   Expected 'var' to have an indentation at 9 instead at 7.
  line 557  col 7   Expected 'messageQueue' to have an indentation at 9 instead at 7.
  line 558  col 7   Expected 'return' to have an indentation at 9 instead at 7.
  line 559  col 5   Expected '}' to have an indentation at 7 instead at 5.
  line 560  col 5   Expected 'onClose' to have an indentation at 7 instead at 5.
  line 561  col 7   Expected 'if' to have an indentation at 9 instead at 7.
  line 562  col 9   Expected 'return' to have an indentation at 11 instead at 9.
  line 563  col 7   Expected '}' to have an indentation at 9 instead at 7.
  line 564  col 7   Expected 'var' to have an indentation at 9 instead at 7.
  line 565  col 7   Expected 'closeQueue' to have an indentation at 9 instead at 7.
  line 566  col 7   Expected 'return' to have an indentation at 9 instead at 7.
  line 567  col 5   Expected '}' to have an indentation at 7 instead at 5.
  line 568  col 5   Expected 'onError' to have an indentation at 7 instead at 5.
  line 569  col 7   Expected 'if' to have an indentation at 9 instead at 7.
  line 569  col 7   Too many errors. (40% scanned).

src/services/projects.js
  line 30   col 15  Expected 'annotationNameFilter' to have an indentation at 11 instead at 15.
  line 31   col 15  Expected 'annotationNameFilter' to have an indentation at 11 instead at 15.
  line 32   col 13  Expected ']' to have an indentation at 9 instead at 13.
  line 83   col 41  Expected 'error' to have an indentation at 35 instead at 41.
  line 84   col 41  Expected 'error_description' to have an indentation at 35 instead at 41.
  line 85   col 39  Expected '}' to have an indentation at 33 instead at 39.
  line 90   col 11  Expected '}' to have an indentation at 9 instead at 11.
  line 96   col 11  Expected 'list' to have an indentation at 9 instead at 11.
  line 114  col 11  Expected 'isProjectListIncomplete' to have an indentation at 9 instead at 11.
  line 118  col 11  Expected 'watch' to have an indentation at 9 instead at 11.
  line 128  col 11  Expected 'update' to have an indentation at 9 instead at 11.
  line 142  col 11  Expected 'create' to have an indentation at 9 instead at 11.
  line 163  col 11  Expected 'canCreate' to have an indentation at 9 instead at 11.
  line 167  col 11  Expected 'delete' to have an indentation at 9 instead at 11.
  line 176  col 9   Expected '}' to have an indentation at 7 instead at 9.
  line 106  col 30  'error' is defined but never used.

src/services/redirectLoginService.js
  line 41   col 4   Missing semicolon.

src/services/ws.js
  line 26   col 1   Mixed spaces and tabs.
  line 28   col 1   Mixed spaces and tabs.

src/ui-services/guidedTourService.js
  line 31   col 5   'hopscotch' is not defined.
  line 35   col 5   'hopscotch' is not defined.
  line 70   col 19  'hopscotch' is not defined.
  line 83   col 19  'hopscotch' is not defined.

```

Most of these are indentation complaints.  Items that could potentially cause errors are:

```JavaScript 
line 200  col 14  'data' is already defined.
line 212  col 17  'headers' is already defined.
Expected '===' and instead saw '=='
Missing "use strict" statement.
```

I added `jshint` to the `build` task, so this PR will fail until the above are fixed.  I can do the cleanup here, unless we want to adjust some of the rules in the `jshintrc`.

@jwforres @spadgett @jeff-phillips-18 