### PR TITLE
Switch karma browser to Firefox for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
   directories:
   - node_modules
   - bower_components
-addons:
-  chrome: stable
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -77,7 +77,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     // CLI --browsers Chrome,Firefox,Safari
-    browsers: [process.env.TRAVIS ? 'Chrome' : 'Chrome'],
+    browsers: [process.env.TRAVIS ? 'Firefox' : 'Chrome'],
 
     // If browser does not capture in given timeout [ms], kill it
     // CLI --capture-timeout 5000


### PR DESCRIPTION
Fix recent build failure issue by using Firefox browser in Karma when building on Travis.