### PR TITLE
Prefer apps/v1 replicasets

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -3812,7 +3812,7 @@ angular.module('openshiftCommonServices')
       projects:                         {group: 'project.openshift.io',       version: 'v1',      resource: 'projects' },
       projectrequests:                  {group: 'project.openshift.io',       version: 'v1',      resource: 'projectrequests' },
       persistentvolumeclaims:           {version: 'v1',                       resource: 'persistentvolumeclaims' },
-      replicasets:                      {group: 'extensions',                 version: 'v1beta1', resource: 'replicasets' },
+      replicasets:                      {group: 'apps',                       version: 'v1',      resource: 'replicasets' },
       replicationcontrollers:           {version: 'v1',                       resource: 'replicationcontrollers' },
       resourcequotas:                   {version: 'v1',                       resource: 'resourcequotas' },
       rolebindings:                     {group: 'rbac.authorization.k8s.io',  version: 'v1',      resource: 'rolebindings' },

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -1448,7 +1448,7 @@ angular.module('openshiftCommonServices')
       projects:                         {group: 'project.openshift.io',       version: 'v1',      resource: 'projects' },
       projectrequests:                  {group: 'project.openshift.io',       version: 'v1',      resource: 'projectrequests' },
       persistentvolumeclaims:           {version: 'v1',                       resource: 'persistentvolumeclaims' },
-      replicasets:                      {group: 'extensions',                 version: 'v1beta1', resource: 'replicasets' },
+      replicasets:                      {group: 'apps',                       version: 'v1',      resource: 'replicasets' },
       replicationcontrollers:           {version: 'v1',                       resource: 'replicationcontrollers' },
       resourcequotas:                   {version: 'v1',                       resource: 'resourcequotas' },
       rolebindings:                     {group: 'rbac.authorization.k8s.io',  version: 'v1',      resource: 'rolebindings' },

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -617,8 +617,8 @@ version:"v1",
 resource:"persistentvolumeclaims"
 },
 replicasets:{
-group:"extensions",
-version:"v1beta1",
+group:"apps",
+version:"v1",
 resource:"replicasets"
 },
 replicationcontrollers:{

--- a/src/constants/apiPreferredVersions.js
+++ b/src/constants/apiPreferredVersions.js
@@ -32,7 +32,7 @@ angular.module('openshiftCommonServices')
       projects:                         {group: 'project.openshift.io',       version: 'v1',      resource: 'projects' },
       projectrequests:                  {group: 'project.openshift.io',       version: 'v1',      resource: 'projectrequests' },
       persistentvolumeclaims:           {version: 'v1',                       resource: 'persistentvolumeclaims' },
-      replicasets:                      {group: 'extensions',                 version: 'v1beta1', resource: 'replicasets' },
+      replicasets:                      {group: 'apps',                       version: 'v1',      resource: 'replicasets' },
       replicationcontrollers:           {version: 'v1',                       resource: 'replicationcontrollers' },
       resourcequotas:                   {version: 'v1',                       resource: 'resourcequotas' },
       rolebindings:                     {group: 'rbac.authorization.k8s.io',  version: 'v1',      resource: 'rolebindings' },


### PR DESCRIPTION
I need to check if there are API changes, but we should be using replicasets from the apps group rather than extensions, which is deprecated.

/assign @jwforres 
/cc @benjaminapetersen 