### PR TITLE
[enterprise-3.9] Fall back to JSON when PartialObjectMetadataList unavailable

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -1406,14 +1406,8 @@ angular.module('openshiftCommonServices')
 angular.module('openshiftCommonServices')
 .factory('DataService', function($cacheFactory, $http, $ws, $rootScope, $q, API_CFG, APIService, Logger, $timeout, base64, base64util) {
 
-  // Accept PartialObjectMetadataList. Unfortunately we can't use the Accept
-  // header to fallback to JSON due to an API server content negotiation bug.
-  // https://github.com/kubernetes/kubernetes/issues/50519
-  //
-  // This is a potential version skew issue for when the web console runs in
-  // a pod where we potentially need to support different server versions.
-  // https://trello.com/c/9oaUh8xP
-  var ACCEPT_PARTIAL_OBJECT_METADATA_LIST = 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io';
+  // This will request just a list of the object metadata, falling back to application/json if needed.
+  var ACCEPT_PARTIAL_OBJECT_METADATA_LIST = 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json';
 
   function Data(array) {
     this._data = {};

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -3473,14 +3473,8 @@ angular.module('openshiftCommonServices')
 angular.module('openshiftCommonServices')
 .factory('DataService', ["$cacheFactory", "$http", "$ws", "$rootScope", "$q", "API_CFG", "APIService", "Logger", "$timeout", "base64", "base64util", function($cacheFactory, $http, $ws, $rootScope, $q, API_CFG, APIService, Logger, $timeout, base64, base64util) {
 
-  // Accept PartialObjectMetadataList. Unfortunately we can't use the Accept
-  // header to fallback to JSON due to an API server content negotiation bug.
-  // https://github.com/kubernetes/kubernetes/issues/50519
-  //
-  // This is a potential version skew issue for when the web console runs in
-  // a pod where we potentially need to support different server versions.
-  // https://trello.com/c/9oaUh8xP
-  var ACCEPT_PARTIAL_OBJECT_METADATA_LIST = 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io';
+  // This will request just a list of the object metadata, falling back to application/json if needed.
+  var ACCEPT_PARTIAL_OBJECT_METADATA_LIST = 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json';
 
   function Data(array) {
     this._data = {};

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1971,13 +1971,13 @@ f.prototype._uniqueKey = function(e, t, n, r) {
 var o, i = n && n.namespace || _.get(n, "project.metadata.name") || n.projectName, a = _.get(r, "http.params"), s = this._urlForResource(e, t, n, null, angular.extend({}, {}, {
 namespace: i
 }));
-return o = s ? s.toString() : e || "<unknown>", o += w(a || {}), _.get(r, "partialObjectMetadataList") ? o + "#application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io" : o;
+return o = s ? s.toString() : e || "<unknown>", o += w(a || {}), _.get(r, "partialObjectMetadataList") ? o + "#application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json" : o;
 }, f.prototype._startListOp = function(e, n, r) {
 r = r || {};
 var o = _.get(r, "http.params") || {}, i = this._uniqueKey(e, null, n, r);
 this._listInFlight(i, !0);
 var a = {};
-r.partialObjectMetadataList && (a.Accept = "application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io");
+r.partialObjectMetadataList && (a.Accept = "application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json");
 var s, c = this;
 if (n.projectPromise && !e.equals("projects")) n.projectPromise.done(function(l) {
 if (!(s = c._urlForResource(e, null, n, !1, _.assign({}, o, {

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -4,14 +4,8 @@
 angular.module('openshiftCommonServices')
 .factory('DataService', function($cacheFactory, $http, $ws, $rootScope, $q, API_CFG, APIService, Logger, $timeout, base64, base64util) {
 
-  // Accept PartialObjectMetadataList. Unfortunately we can't use the Accept
-  // header to fallback to JSON due to an API server content negotiation bug.
-  // https://github.com/kubernetes/kubernetes/issues/50519
-  //
-  // This is a potential version skew issue for when the web console runs in
-  // a pod where we potentially need to support different server versions.
-  // https://trello.com/c/9oaUh8xP
-  var ACCEPT_PARTIAL_OBJECT_METADATA_LIST = 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io';
+  // This will request just a list of the object metadata, falling back to application/json if needed.
+  var ACCEPT_PARTIAL_OBJECT_METADATA_LIST = 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json';
 
   function Data(array) {
     this._data = {};


### PR DESCRIPTION
Use content negotiation to fall back to JSON when
v1alpha1/PartialObjectMetadataList is not available. In 3.10,
PartialObjectMetadataList was promoted to beta. This prevents a problem
where a 3.9 console will show errors when connecting to a 3.10 master.

/assign @jwforres 