### PR TITLE
Assign metadata on binding creation

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -1652,16 +1652,15 @@ angular.module("openshiftCommonServices")
       return secret;
     };
 
-    var makeBinding = function(serviceInstance, application, parametersSecretName) {
+    var makeBinding = function(serviceInstance, application, parametersSecretName, metadata) {
       var instanceName = serviceInstance.metadata.name;
 
+      metadata = _.assign({ generateName: instanceName + '-' }, metadata);
       var credentialSecretName = generateSecretName(serviceInstance.metadata.name + '-credentials-');
       var binding = {
         kind: 'ServiceBinding',
         apiVersion: 'servicecatalog.k8s.io/v1beta1',
-        metadata: {
-          generateName: instanceName + '-'
-        },
+        metadata: metadata,
         spec: {
           instanceRef: {
             name: instanceName
@@ -1793,13 +1792,13 @@ angular.module("openshiftCommonServices")
       // is specified, also create a pod preset for that application using its
       // `spec.selector`. `serviceClass` is required to determine if any
       // parameters need to be set when creating the binding.
-      bindService: function(serviceInstance, application, serviceClass, parameters) {
+      bindService: function(serviceInstance, application, serviceClass, parameters, metadata) {
         var parametersSecretName;
         if (!_.isEmpty(parameters)) {
           parametersSecretName = generateSecretName(serviceInstance.metadata.name + '-bind-parameters-');
         }
 
-        var newBinding = makeBinding(serviceInstance, application, parametersSecretName);
+        var newBinding = makeBinding(serviceInstance, application, parametersSecretName, metadata);
         var context = {
           namespace: serviceInstance.metadata.namespace
         };

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -2970,16 +2970,15 @@ angular.module("openshiftCommonServices")
       return secret;
     };
 
-    var makeBinding = function(serviceInstance, application, parametersSecretName) {
+    var makeBinding = function(serviceInstance, application, parametersSecretName, metadata) {
       var instanceName = serviceInstance.metadata.name;
 
+      metadata = _.assign({ generateName: instanceName + '-' }, metadata);
       var credentialSecretName = generateSecretName(serviceInstance.metadata.name + '-credentials-');
       var binding = {
         kind: 'ServiceBinding',
         apiVersion: 'servicecatalog.k8s.io/v1beta1',
-        metadata: {
-          generateName: instanceName + '-'
-        },
+        metadata: metadata,
         spec: {
           instanceRef: {
             name: instanceName
@@ -3111,13 +3110,13 @@ angular.module("openshiftCommonServices")
       // is specified, also create a pod preset for that application using its
       // `spec.selector`. `serviceClass` is required to determine if any
       // parameters need to be set when creating the binding.
-      bindService: function(serviceInstance, application, serviceClass, parameters) {
+      bindService: function(serviceInstance, application, serviceClass, parameters, metadata) {
         var parametersSecretName;
         if (!_.isEmpty(parameters)) {
           parametersSecretName = generateSecretName(serviceInstance.metadata.name + '-bind-parameters-');
         }
 
-        var newBinding = makeBinding(serviceInstance, application, parametersSecretName);
+        var newBinding = makeBinding(serviceInstance, application, parametersSecretName, metadata);
         var context = {
           namespace: serviceInstance.metadata.namespace
         };

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -1261,33 +1261,35 @@ type: "Opaque",
 stringData: {}
 };
 return r.stringData.parameters = JSON.stringify(t), r;
-}, d = function(e, t, n) {
-var r = e.metadata.name, o = l(e.metadata.name + "-credentials-"), i = {
+}, d = function(e, t, n, r) {
+var o = e.metadata.name;
+r = _.assign({
+generateName: o + "-"
+}, r);
+var i = l(e.metadata.name + "-credentials-"), a = {
 kind: "ServiceBinding",
 apiVersion: "servicecatalog.k8s.io/v1beta1",
-metadata: {
-generateName: r + "-"
-},
+metadata: r,
 spec: {
 instanceRef: {
-name: r
+name: o
 },
-secretName: o
+secretName: i
 }
 };
-n && (i.spec.parametersFrom = [ {
+n && (a.spec.parametersFrom = [ {
 secretKeyRef: {
 name: n,
 key: "parameters"
 }
 } ]);
-var a = _.get(t, "spec.selector");
-return a && (a.matchLabels || a.matchExpressions || (a = {
-matchLabels: a
-}), i.spec.alphaPodPresetTemplate = {
-name: o,
-selector: a
-}), i;
+var s = _.get(t, "spec.selector");
+return s && (s.matchLabels || s.matchExpressions || (s = {
+matchLabels: s
+}), a.spec.alphaPodPresetTemplate = {
+name: i,
+selector: s
+}), a;
 }, p = function(t, n, r) {
 if (!t || !n || !r) return !1;
 if (_.get(t, "metadata.deletionTimestamp")) return !1;
@@ -1310,18 +1312,18 @@ return n ? t[n] : null;
 },
 makeParametersSecret: u,
 generateSecretName: l,
-bindService: function(e, t, n, r) {
-var i;
-_.isEmpty(r) || (i = l(e.metadata.name + "-bind-parameters-"));
-var c = d(e, t, i), p = {
+bindService: function(e, t, n, r, i) {
+var c;
+_.isEmpty(r) || (c = l(e.metadata.name + "-bind-parameters-"));
+var p = d(e, t, c, i), f = {
 namespace: e.metadata.namespace
-}, f = o.create(a, null, c, p);
-return i ? f.then(function(e) {
-var t = u(i, r, e);
-return o.create(s, null, t, p).then(function() {
+}, g = o.create(a, null, p, f);
+return c ? g.then(function(e) {
+var t = u(c, r, e);
+return o.create(s, null, t, f).then(function() {
 return e;
 });
-}) : f;
+}) : g;
 },
 isServiceBindable: p,
 getPodPresetSelectorsForBindings: f,

--- a/src/services/bindService.js
+++ b/src/services/bindService.js
@@ -66,16 +66,15 @@ angular.module("openshiftCommonServices")
       return secret;
     };
 
-    var makeBinding = function(serviceInstance, application, parametersSecretName) {
+    var makeBinding = function(serviceInstance, application, parametersSecretName, metadata) {
       var instanceName = serviceInstance.metadata.name;
 
+      metadata = _.assign({ generateName: instanceName + '-' }, metadata);
       var credentialSecretName = generateSecretName(serviceInstance.metadata.name + '-credentials-');
       var binding = {
         kind: 'ServiceBinding',
         apiVersion: 'servicecatalog.k8s.io/v1beta1',
-        metadata: {
-          generateName: instanceName + '-'
-        },
+        metadata: metadata,
         spec: {
           instanceRef: {
             name: instanceName
@@ -207,13 +206,13 @@ angular.module("openshiftCommonServices")
       // is specified, also create a pod preset for that application using its
       // `spec.selector`. `serviceClass` is required to determine if any
       // parameters need to be set when creating the binding.
-      bindService: function(serviceInstance, application, serviceClass, parameters) {
+      bindService: function(serviceInstance, application, serviceClass, parameters, metadata) {
         var parametersSecretName;
         if (!_.isEmpty(parameters)) {
           parametersSecretName = generateSecretName(serviceInstance.metadata.name + '-bind-parameters-');
         }
 
-        var newBinding = makeBinding(serviceInstance, application, parametersSecretName);
+        var newBinding = makeBinding(serviceInstance, application, parametersSecretName, metadata);
         var context = {
           namespace: serviceInstance.metadata.namespace
         };


### PR DESCRIPTION
As part of ongoing mobile work we would like to be able to configure the metadata applied to ServiceBindings on creation. The aim is to add labels or annotations to the ServiceBinding to be able identify and then work with that specific binding.