### PR TITLE
Bug 1585114 - Remove ReplicationControllerDummy from other resources list

### DIFF
--- a/dist/origin-web-common-services.js
+++ b/dist/origin-web-common-services.js
@@ -4398,7 +4398,8 @@ angular.module('openshiftCommonServices')
     kinds: [
       {group: 'extensions', kind: 'DaemonSet'},
       {group: 'extensions', kind: 'HorizontalPodAutoscaler'},
-      {group: 'extensions', kind: 'NetworkPolicy'}
+      {group: 'extensions', kind: 'NetworkPolicy'},
+      {group: 'extensions', kind: 'ReplicationControllerDummy'}
     ]
   });
 ;

--- a/dist/origin-web-common.js
+++ b/dist/origin-web-common.js
@@ -1087,7 +1087,8 @@ angular.module('openshiftCommonServices')
     kinds: [
       {group: 'extensions', kind: 'DaemonSet'},
       {group: 'extensions', kind: 'HorizontalPodAutoscaler'},
-      {group: 'extensions', kind: 'NetworkPolicy'}
+      {group: 'extensions', kind: 'NetworkPolicy'},
+      {group: 'extensions', kind: 'ReplicationControllerDummy'}
     ]
   });
 ;

--- a/dist/origin-web-common.min.js
+++ b/dist/origin-web-common.min.js
@@ -259,6 +259,9 @@ kind: "HorizontalPodAutoscaler"
 }, {
 group: "extensions",
 kind: "NetworkPolicy"
+}, {
+group: "extensions",
+kind: "ReplicationControllerDummy"
 } ]
 }), angular.module("openshiftCommonServices").constant("API_PREFERRED_VERSIONS", {
 appliedclusterresourcequotas: {

--- a/src/constants/apiDedupe.js
+++ b/src/constants/apiDedupe.js
@@ -8,6 +8,7 @@ angular.module('openshiftCommonServices')
     kinds: [
       {group: 'extensions', kind: 'DaemonSet'},
       {group: 'extensions', kind: 'HorizontalPodAutoscaler'},
-      {group: 'extensions', kind: 'NetworkPolicy'}
+      {group: 'extensions', kind: 'NetworkPolicy'},
+      {group: 'extensions', kind: 'ReplicationControllerDummy'}
     ]
   });


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1585114

Fixes this problem:

![screen shot 2018-06-01 at 8 54 26 am](https://user-images.githubusercontent.com/1167259/40843063-c8d613c6-657d-11e8-9358-beed35cecf70.png)

/assign @rhamilto 
